### PR TITLE
AN-2944/bsc-price-pivot

### DIFF
--- a/models/gold/core__ez_bnb_transfers.sql
+++ b/models/gold/core__ez_bnb_transfers.sql
@@ -25,7 +25,7 @@ WITH bnb_base AS (
 token_prices AS (
     SELECT
         HOUR,
-        AVG(price) AS bnb_price
+        price AS bnb_price
     FROM
         {{ source(
             'ethereum',
@@ -33,8 +33,6 @@ token_prices AS (
         ) }}
     WHERE
         token_address = LOWER('0x418D75f65a02b3D53B2418FB8E1fe493759c7605')
-    GROUP BY
-        HOUR
 )
 SELECT
     A.tx_hash AS tx_hash,

--- a/models/gold/core__ez_token_transfers.sql
+++ b/models/gold/core__ez_token_transfers.sql
@@ -1,0 +1,45 @@
+{{ config(
+    materialized = 'view',
+    persist_docs ={ "relation": true,
+    "columns": true }
+) }}
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    from_address,
+    to_address,
+    raw_amount,
+    decimals,
+    symbol,
+    price AS token_price,
+    CASE
+        WHEN decimals IS NOT NULL THEN raw_amount / pow(
+            10,
+            decimals
+        )
+        ELSE NULL
+    END AS amount,
+    CASE
+        WHEN decimals IS NOT NULL AND price IS NOT NULL THEN amount * price
+        ELSE NULL
+    END AS amount_usd,
+    CASE
+        WHEN decimals IS NULL THEN 'false'
+        ELSE 'true'
+    END AS has_decimal,
+    CASE
+        WHEN price IS NULL THEN 'false'
+        ELSE 'true'
+    END AS has_price,
+    _log_id
+FROM
+    {{ ref('core__fact_token_transfers') }} t
+LEFT JOIN {{ ref('core__fact_hourly_token_prices') }} p 
+    ON t.contract_address = p.token_address 
+        AND DATE_TRUNC('hour', t.block_timestamp) = HOUR

--- a/models/gold/core__ez_token_transfers.yml
+++ b/models/gold/core__ez_token_transfers.yml
@@ -1,0 +1,42 @@
+version: 2
+models:
+  - name: core__ez_token_transfers
+    description: '{{ doc("bsc_transfer_table_doc") }}'
+      
+    columns:
+      - name: BLOCK_NUMBER
+        description: '{{ doc("bsc_block_number") }}'   
+      - name: BLOCK_TIMESTAMP
+        description: '{{ doc("bsc_block_timestamp") }}'
+      - name: TX_HASH
+        description: '{{ doc("bsc_transfer_tx_hash") }}'
+      - name: CONTRACT_ADDRESS
+        description: '{{ doc("bsc_transfer_contract_address") }}'
+      - name: FROM_ADDRESS
+        description: '{{ doc("bsc_transfer_from_address") }}'
+      - name: TO_ADDRESS
+        description: '{{ doc("bsc_transfer_to_address") }}'
+      - name: RAW_AMOUNT
+        description: '{{ doc("bsc_transfer_raw_amount") }}'
+      - name: DECIMALS
+        description: 'The number of decimal places this contract needs adjusted where token values exist.'
+      - name: SYMBOL
+        description: 'The symbol belonging to the address of the token.'
+      - name: TOKEN_PRICE
+        description: '{{ doc("bsc_transfer_token_price") }}'
+      - name: AMOUNT
+        description: '{{ doc("bsc_transfer_amount") }}'
+      - name: AMOUNT_USD
+        description: '{{ doc("bsc_transfer_amount_usd") }}'
+      - name: HAS_DECIMAL
+        description: '{{ doc("bsc_transfer_has_decimal") }}'
+      - name: HAS_PRICE
+        description: '{{ doc("bsc_transfer_has_price") }}'
+      - name: _LOG_ID
+        description: '{{ doc("bsc_log_id_transfers") }}'
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        description: '{{ doc("bsc_origin_sig") }}'
+      - name: ORIGIN_FROM_ADDRESS
+        description: '{{ doc("bsc_origin_from") }}'
+      - name: ORIGIN_TO_ADDRESS
+        description: '{{ doc("bsc_origin_to") }}'

--- a/models/gold/core__fact_hourly_token_prices.sql
+++ b/models/gold/core__fact_hourly_token_prices.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized = 'view',
+    persist_docs ={ "relation": true,
+    "columns": true }
+) }}
+
+SELECT
+    HOUR,
+    token_address,
+    symbol,
+    decimals,
+    price,
+    is_imputed
+FROM
+    {{ source(
+        'crosschain',
+        'ez_hourly_prices'
+    ) }}
+WHERE blockchain = 'bsc'

--- a/models/gold/core__fact_hourly_token_prices.yml
+++ b/models/gold/core__fact_hourly_token_prices.yml
@@ -18,6 +18,6 @@ models:
       - name: DECIMALS
         description: 'The decimals for this token.'
       - name: PRICE
-        description: 'The average hourly price for this token.'
+        description: 'The closing hourly price for this token.'
       - name: IS_IMPUTED
         description: 'This column denotes if we carried forward the last recorded price in order to fill hourly gaps from the source. Either true or false.'

--- a/models/gold/core__fact_hourly_token_prices.yml
+++ b/models/gold/core__fact_hourly_token_prices.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+
+  - name: core__fact_hourly_token_prices
+    description: 'This table contains the hourly USD prices for tokens on the BSC blockchain.'
+      
+    columns:
+      - name: HOUR
+        description: 'The hour the token price was recorded.'
+        tests:
+          - not_null
+      - name: TOKEN_ADDRESS
+        description: 'The BSC contract address for this token. This is the column used to join to token contract addresses in the other event tables.'
+        tests:
+          - not_null
+      - name: SYMBOL
+        description: 'The symbol for this token.'
+      - name: DECIMALS
+        description: 'The decimals for this token.'
+      - name: PRICE
+        description: 'The average hourly price for this token.'
+      - name: IS_IMPUTED
+        description: 'This column denotes if we carried forward the last recorded price in order to fill hourly gaps from the source. Either true or false.'

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -12,6 +12,7 @@ sources:
     schema: core
     tables:
       - name: address_labels
+      - name: ez_hourly_prices
   - name: ethereum
     database: ethereum
     schema: core

--- a/models/sushi/sushi__dim_dex_pools.sql
+++ b/models/sushi/sushi__dim_dex_pools.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'table',
+    enabled = false,
     meta={
         'database_tags':{
             'table': {

--- a/models/sushi/sushi__dim_dex_pools.yml
+++ b/models/sushi/sushi__dim_dex_pools.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: sushi__dim_dex_pools
-    description: Deprecating soon
+    # description: Deprecating soon
        
 
     # columns:

--- a/models/sushi/sushi__dim_kashi_pairs.sql
+++ b/models/sushi/sushi__dim_kashi_pairs.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'table',
+    enabled = false,
     meta={
         'database_tags':{
             'table': {

--- a/models/sushi/sushi__dim_kashi_pairs.yml
+++ b/models/sushi/sushi__dim_kashi_pairs.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: sushi__dim_kashi_pairs
-    description: Deprecating soon
+    # description: Deprecating soon
        
 
     # columns:

--- a/models/sushi/sushi__ez_borrowing.sql
+++ b/models/sushi/sushi__ez_borrowing.sql
@@ -7,7 +7,7 @@
   cluster_by = ['block_timestamp::DATE'],
   enabled = false,
   meta ={ 'database_tags':{ 'table':{ 'PROTOCOL': 'SUSHI',
-  'PURPOSE': 'DEFI, DEX' }} }
+  'PURPOSE': 'DEFI, DEX' } } }
 ) }}
 
 WITH borrow_txns AS (

--- a/models/sushi/sushi__ez_borrowing.yml
+++ b/models/sushi/sushi__ez_borrowing.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: sushi__ez_borrowing
-    description: Deprecating soon
+    # description: Deprecating soon
     # tests:
     #   - dbt_utils.unique_combination_of_columns:
     #       combination_of_columns:

--- a/models/sushi/sushi__ez_lending.sql
+++ b/models/sushi/sushi__ez_lending.sql
@@ -7,7 +7,7 @@
   cluster_by = ['block_timestamp::DATE'],
   enabled = false,
   meta ={ 'database_tags':{ 'table':{ 'PROTOCOL': 'SUSHI',
-  'PURPOSE': 'DEFI, DEX' }} }
+  'PURPOSE': 'DEFI, DEX' } } }
 ) }}
 
 WITH borrow_txns AS (

--- a/models/sushi/sushi__ez_lending.yml
+++ b/models/sushi/sushi__ez_lending.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: sushi__ez_lending
-    description: Deprecating soon
+    # description: Deprecating soon
 
     # tests:
     #   - dbt_utils.unique_combination_of_columns:

--- a/models/sushi/sushi__ez_swaps.sql
+++ b/models/sushi/sushi__ez_swaps.sql
@@ -4,8 +4,9 @@
     "columns": true },
     unique_key = '_log_id',
     cluster_by = ['block_timestamp::DATE'],
+    enabled = false,
     meta ={ 'database_tags':{ 'table':{ 'PROTOCOL': 'SUSHI',
-    'PURPOSE': 'DEFI, DEX, SWAPS' }} }
+    'PURPOSE': 'DEFI, DEX, SWAPS' } } }
 ) }}
 
 WITH swap_events AS (

--- a/models/sushi/sushi__ez_swaps.yml
+++ b/models/sushi/sushi__ez_swaps.yml
@@ -1,148 +1,148 @@
 version: 2
 models:
   - name: sushi__ez_swaps
-    description: Deprecating soon
+    # description: Deprecating soon
 
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - _LOG_ID
-    columns:
-      - name: BLOCK_NUMBER
-        description: '{{ doc("bsc_block_number") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: BLOCK_TIMESTAMP
-        description: '{{ doc("bsc_block_timestamp") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 5 #might be normal for swaps not to happen on a day
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - TIMESTAMP_NTZ
-      - name: TX_HASH
-        description: '{{ doc("bsc_logs_tx_hash") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: CONTRACT_ADDRESS
-        description: '{{ doc("bsc_logs_contract_address") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: EVENT_NAME
-        description: '{{ doc("bsc_event_name") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
-      - name: AMOUNT_IN
-        description: '{{ doc("eth_dex_swaps_amount_in") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: AMOUNT_OUT
-        description: '{{ doc("eth_dex_swaps_amount_out") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: AMOUNT_IN_USD
-        description: '{{ doc("eth_dex_swaps_amount_in_usd") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: AMOUNT_OUT_USD
-        description: '{{ doc("eth_dex_swaps_amount_out_usd") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: TOKEN_IN
-        description: '{{ doc("eth_dex_swaps_token_in") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
+    # tests:
+    #   - dbt_utils.unique_combination_of_columns:
+    #       combination_of_columns:
+    #         - _LOG_ID
+    # columns:
+    #   - name: BLOCK_NUMBER
+    #     description: '{{ doc("bsc_block_number") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: BLOCK_TIMESTAMP
+    #     description: '{{ doc("bsc_block_timestamp") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_row_values_to_have_recent_data:
+    #           datepart: day
+    #           interval: 5 #might be normal for swaps not to happen on a day
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - TIMESTAMP_NTZ
+    #   - name: TX_HASH
+    #     description: '{{ doc("bsc_logs_tx_hash") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: CONTRACT_ADDRESS
+    #     description: '{{ doc("bsc_logs_contract_address") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: EVENT_NAME
+    #     description: '{{ doc("bsc_event_name") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - STRING
+    #             - VARCHAR
+    #   - name: AMOUNT_IN
+    #     description: '{{ doc("eth_dex_swaps_amount_in") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: AMOUNT_OUT
+    #     description: '{{ doc("eth_dex_swaps_amount_out") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: AMOUNT_IN_USD
+    #     description: '{{ doc("eth_dex_swaps_amount_in_usd") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: AMOUNT_OUT_USD
+    #     description: '{{ doc("eth_dex_swaps_amount_out_usd") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: TOKEN_IN
+    #     description: '{{ doc("eth_dex_swaps_token_in") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
 
-      - name: TOKEN_OUT
-        description: '{{ doc("eth_dex_swaps_token_out") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: SYMBOL_IN
-        description: '{{ doc("eth_dex_swaps_symbol_in") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
-      - name: SYMBOL_OUT
-        description: '{{ doc("eth_dex_swaps_symbol_out") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
-      - name: SENDER
-        description: '{{ doc("eth_dex_swaps_sender") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: TX_TO
-        description: '{{ doc("eth_dex_swaps_tx_to") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: PLATFORM
-        description: '{{ doc("eth_dex_platform") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
-      - name: EVENT_INDEX
-        description: '{{ doc("bsc_event_index") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: _LOG_ID
-        description: '{{ doc("bsc_log_id_events") }}'
-        tests:
-          - not_null
-      - name: ORIGIN_FUNCTION_SIGNATURE
-        description: '{{ doc("bsc_tx_origin_sig") }}'
-        tests:
-          - not_null
-      - name: ORIGIN_FROM_ADDRESS
-        description: '{{ doc("bsc_origin_from") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: ORIGIN_TO_ADDRESS
-        description: '{{ doc("bsc_origin_to") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
+    #   - name: TOKEN_OUT
+    #     description: '{{ doc("eth_dex_swaps_token_out") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: SYMBOL_IN
+    #     description: '{{ doc("eth_dex_swaps_symbol_in") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - STRING
+    #             - VARCHAR
+    #   - name: SYMBOL_OUT
+    #     description: '{{ doc("eth_dex_swaps_symbol_out") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - STRING
+    #             - VARCHAR
+    #   - name: SENDER
+    #     description: '{{ doc("eth_dex_swaps_sender") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: TX_TO
+    #     description: '{{ doc("eth_dex_swaps_tx_to") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: PLATFORM
+    #     description: '{{ doc("eth_dex_platform") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - STRING
+    #             - VARCHAR
+    #   - name: EVENT_INDEX
+    #     description: '{{ doc("bsc_event_index") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: _LOG_ID
+    #     description: '{{ doc("bsc_log_id_events") }}'
+    #     tests:
+    #       - not_null
+    #   - name: ORIGIN_FUNCTION_SIGNATURE
+    #     description: '{{ doc("bsc_tx_origin_sig") }}'
+    #     tests:
+    #       - not_null
+    #   - name: ORIGIN_FROM_ADDRESS
+    #     description: '{{ doc("bsc_origin_from") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: ORIGIN_TO_ADDRESS
+    #     description: '{{ doc("bsc_origin_to") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
 


### PR DESCRIPTION
1. Added `core.fact_hourly_token_prices` built off `crosschain` and updated references accordingly
2. Disabled sushi models as part of deprecation process