### PR TITLE
prepare bsc contracts for launch

### DIFF
--- a/.github/workflows/dbt_run_temp_contracts.yml
+++ b/.github/workflows/dbt_run_temp_contracts.yml
@@ -1,11 +1,11 @@
-name: dbt_run_scheduled
-run-name: dbt_run_scheduled
+name: dbt_run_temp_contracts
+run-name: dbt_run_temp_contracts
 
 on:
   workflow_dispatch:
   schedule:
-    # Runs "every 2 hours" (see https://crontab.guru)
-    - cron: '0 */2 * * *'
+    # Runs "every 20 mins" (see https://crontab.guru)
+    - cron: '*/20 * * * *'
     
 env:
   DBT_PROFILES_DIR: ./
@@ -41,4 +41,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --exclude models/silver/API_udf models/bronze/api_udf/bronze_api__token_reads.sql+
+          dbt run -m models/bronze/api_udf/bronze_api__token_reads.sql+

--- a/models/silver/silver__contracts.sql
+++ b/models/silver/silver__contracts.sql
@@ -1,0 +1,116 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'contract_address'
+) }}
+
+WITH base_metadata AS (
+
+    SELECT
+        contract_address,
+        block_number,
+        function_sig AS function_signature,
+        read_result AS read_output,
+        _inserted_timestamp
+    FROM
+        {{ ref('bronze_api__token_reads') }}
+    WHERE
+        read_result IS NOT NULL
+        AND read_result <> '0x'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(
+            _inserted_timestamp
+        )
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+token_names AS (
+    SELECT
+        contract_address,
+        block_number,
+        function_signature,
+        read_output,
+        regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_output,
+        LTRIM(
+            REGEXP_REPLACE(
+                TRY_HEX_DECODE_STRING(
+                    segmented_output [2] :: STRING
+                ),
+                '[\x00-\x1F\x7F-\x9F\xAD]',
+                '',
+                1
+            )
+        ) AS token_name
+    FROM
+        base_metadata
+    WHERE
+        function_signature = '0x06fdde03'
+        AND segmented_output [1] :: STRING IS NOT NULL
+),
+token_symbols AS (
+    SELECT
+        contract_address,
+        block_number,
+        function_signature,
+        read_output,
+        regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_output,
+        LTRIM(
+            REGEXP_REPLACE(
+                TRY_HEX_DECODE_STRING(
+                    segmented_output [2] :: STRING
+                ),
+                '[\x00-\x1F\x7F-\x9F\xAD]',
+                '',
+                1
+            )
+        ) AS token_symbol
+    FROM
+        base_metadata
+    WHERE
+        function_signature = '0x95d89b41'
+        AND segmented_output [1] :: STRING IS NOT NULL
+),
+token_decimals AS (
+    SELECT
+        contract_address,
+        PUBLIC.udf_hex_to_int(
+            read_output :: STRING
+        ) AS token_decimals,
+        LENGTH(token_decimals) AS dec_length
+    FROM
+        base_metadata
+    WHERE
+        function_signature = '0x313ce567'
+        AND read_output IS NOT NULL
+        AND read_output <> '0x'
+),
+contracts AS (
+    SELECT
+        contract_address,
+        MAX(_inserted_timestamp) AS _inserted_timestamp
+    FROM
+        base_metadata
+    GROUP BY
+        1
+)
+SELECT
+    c1.contract_address :: STRING AS contract_address,
+    token_name,
+    TRY_TO_NUMBER(token_decimals) AS token_decimals,
+    token_symbol,
+    _inserted_timestamp
+FROM
+    contracts c1
+    LEFT JOIN token_names
+    ON c1.contract_address = token_names.contract_address
+    LEFT JOIN token_symbols
+    ON c1.contract_address = token_symbols.contract_address
+    LEFT JOIN token_decimals
+    ON c1.contract_address = token_decimals.contract_address
+    AND dec_length < 3 qualify(ROW_NUMBER() over(PARTITION BY c1.contract_address
+ORDER BY
+    _inserted_timestamp DESC)) = 1

--- a/models/silver/silver__contracts.yml
+++ b/models/silver/silver__contracts.yml
@@ -1,0 +1,24 @@
+version: 2
+models:
+  - name: silver__contracts
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - CONTRACT_ADDRESS
+    columns:
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null  
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING 
+                - VARCHAR   
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ


### PR DESCRIPTION
- increases efficiency and concurrency of token reads models, ~100k tokens left to get and this will do ~72k a day 
- builds `silver__contracts` with new function for decoding hex strings