### PR TITLE
An 3027/history models

### DIFF
--- a/.github/workflows/dbt_run_streamline_decoder_history1.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history1.yml
@@ -1,11 +1,10 @@
-name: dbt_run_streamline_decoder
-run-name: dbt_run_streamline_decoder
+name: dbt_run_streamline_decoder_history1
+run-name: dbt_run_streamline_decoder_history1
 
 on:
   workflow_dispatch:
-  schedule:
-    # Runs "every 2 hours" (see https://crontab.guru)
-    - cron: '0 */2 * * *'
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: ./
@@ -26,7 +25,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment: 
-      name: workflow_prod
+      name: workflow_prod_backfill
 
     steps:
       - uses: actions/checkout@v3
@@ -41,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder --exclude models/silver/streamline/decoder/history
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_1

--- a/.github/workflows/dbt_run_streamline_decoder_history1.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history1.yml
@@ -40,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_1
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m 1+models/silver/streamline/decoder/history/range_1

--- a/.github/workflows/dbt_run_streamline_decoder_history2.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history2.yml
@@ -40,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_2
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m 1+models/silver/streamline/decoder/history/range_2

--- a/.github/workflows/dbt_run_streamline_decoder_history2.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history2.yml
@@ -1,11 +1,10 @@
-name: dbt_run_streamline_decoder
-run-name: dbt_run_streamline_decoder
+name: dbt_run_streamline_decoder_history2
+run-name: dbt_run_streamline_decoder_history2
 
 on:
   workflow_dispatch:
-  schedule:
-    # Runs "every 2 hours" (see https://crontab.guru)
-    - cron: '0 */2 * * *'
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: ./
@@ -26,7 +25,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment: 
-      name: workflow_prod
+      name: workflow_prod_backfill
 
     steps:
       - uses: actions/checkout@v3
@@ -41,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder --exclude models/silver/streamline/decoder/history
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_2

--- a/.github/workflows/dbt_run_streamline_decoder_history3.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history3.yml
@@ -1,11 +1,10 @@
-name: dbt_run_streamline_decoder
-run-name: dbt_run_streamline_decoder
+name: dbt_run_streamline_decoder_history3
+run-name: dbt_run_streamline_decoder_history3
 
 on:
   workflow_dispatch:
-  schedule:
-    # Runs "every 2 hours" (see https://crontab.guru)
-    - cron: '0 */2 * * *'
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: ./
@@ -26,7 +25,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment: 
-      name: workflow_prod
+      name: workflow_prod_backfill
 
     steps:
       - uses: actions/checkout@v3
@@ -41,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder --exclude models/silver/streamline/decoder/history
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_3

--- a/.github/workflows/dbt_run_streamline_decoder_history3.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history3.yml
@@ -40,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_3
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m 1+models/silver/streamline/decoder/history/range_3

--- a/.github/workflows/dbt_run_streamline_decoder_history4.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history4.yml
@@ -40,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_4
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m 1+models/silver/streamline/decoder/history/range_4

--- a/.github/workflows/dbt_run_streamline_decoder_history4.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history4.yml
@@ -1,11 +1,10 @@
-name: dbt_run_streamline_decoder
-run-name: dbt_run_streamline_decoder
+name: dbt_run_streamline_decoder_history4
+run-name: dbt_run_streamline_decoder_history4
 
 on:
   workflow_dispatch:
-  schedule:
-    # Runs "every 2 hours" (see https://crontab.guru)
-    - cron: '0 */2 * * *'
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: ./
@@ -26,7 +25,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment: 
-      name: workflow_prod
+      name: workflow_prod_backfill
 
     steps:
       - uses: actions/checkout@v3
@@ -41,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder --exclude models/silver/streamline/decoder/history
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_4

--- a/.github/workflows/dbt_run_streamline_decoder_history5.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history5.yml
@@ -40,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_5
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m 1+models/silver/streamline/decoder/history/range_5

--- a/.github/workflows/dbt_run_streamline_decoder_history5.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history5.yml
@@ -1,11 +1,10 @@
-name: dbt_run_streamline_decoder
-run-name: dbt_run_streamline_decoder
+name: dbt_run_streamline_decoder_history5
+run-name: dbt_run_streamline_decoder_history5
 
 on:
   workflow_dispatch:
-  schedule:
-    # Runs "every 2 hours" (see https://crontab.guru)
-    - cron: '0 */2 * * *'
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: ./
@@ -26,7 +25,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment: 
-      name: workflow_prod
+      name: workflow_prod_backfill
 
     steps:
       - uses: actions/checkout@v3
@@ -41,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder --exclude models/silver/streamline/decoder/history
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_5

--- a/.github/workflows/dbt_run_streamline_decoder_history6.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history6.yml
@@ -40,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_6
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m 1+models/silver/streamline/decoder/history/range_6

--- a/.github/workflows/dbt_run_streamline_decoder_history6.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history6.yml
@@ -1,11 +1,10 @@
-name: dbt_run_streamline_decoder
-run-name: dbt_run_streamline_decoder
+name: dbt_run_streamline_decoder_history6
+run-name: dbt_run_streamline_decoder_history6
 
 on:
   workflow_dispatch:
-  schedule:
-    # Runs "every 2 hours" (see https://crontab.guru)
-    - cron: '0 */2 * * *'
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: ./
@@ -26,7 +25,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment: 
-      name: workflow_prod
+      name: workflow_prod_backfill
 
     steps:
       - uses: actions/checkout@v3
@@ -41,4 +40,4 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run --vars '{"STREAMLINE_INVOKE_STREAMS":True}' -m models/silver/streamline/decoder --exclude models/silver/streamline/decoder/history
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":600}' -m models/silver/streamline/decoder/history/range_6

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007500000_007523119.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007500000_007523119.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007523120_007545422.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007523120_007545422.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007545423_007567414.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007545423_007567414.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007567415_007590705.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007567415_007590705.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007590706_007617400.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007590706_007617400.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007617401_007654189.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007617401_007654189.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007654190_007687477.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007654190_007687477.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007687478_007717864.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007687478_007717864.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007717865_007750188.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007717865_007750188.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007750189_007777366.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007750189_007777366.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007777367_007807860.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007777367_007807860.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007807861_007842907.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007807861_007842907.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007842908_007881559.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007842908_007881559.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007881560_007913907.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007881560_007913907.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007913908_007943634.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007913908_007943634.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007943635_007974347.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007943635_007974347.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007974348_008005957.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_007974348_008005957.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008005958_008039285.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008005958_008039285.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008039286_008077257.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008039286_008077257.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008077258_008107963.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008077258_008107963.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008107964_008146506.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008107964_008146506.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008146507_008180707.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008146507_008180707.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008180708_008219284.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008180708_008219284.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008219285_008262303.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008219285_008262303.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008262304_008300103.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008262304_008300103.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008300104_008338137.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008300104_008338137.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008338138_008373900.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008338138_008373900.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008373901_008408781.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008373901_008408781.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008408782_008451655.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008408782_008451655.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008451656_008493412.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008451656_008493412.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008493413_008533742.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008493413_008533742.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008533743_008575437.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008533743_008575437.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008575438_008616288.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008575438_008616288.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008616289_008666108.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008616289_008666108.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008666109_008714484.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008666109_008714484.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008714485_008761625.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008714485_008761625.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008761626_008809571.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008761626_008809571.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008809572_008861301.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008809572_008861301.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008861302_008900640.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008861302_008900640.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008900641_008943014.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008900641_008943014.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008943015_008984069.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008943015_008984069.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008984070_009027338.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_008984070_009027338.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009027339_009074824.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009027339_009074824.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009074825_009116674.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009074825_009116674.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009116675_009159461.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009116675_009159461.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009159462_009206531.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009159462_009206531.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009206532_009256789.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009206532_009256789.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009256790_009296729.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009256790_009296729.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009296730_009334536.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009296730_009334536.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009334537_009370733.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009334537_009370733.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009370734_009400905.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009370734_009400905.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009400906_009425947.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009400906_009425947.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009425948_009450602.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009425948_009450602.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009450603_009474648.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009450603_009474648.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009474649_009497807.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009474649_009497807.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009497808_009518610.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009497808_009518610.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009518611_009537534.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009518611_009537534.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009537535_009556334.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009537535_009556334.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009556335_009573931.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009556335_009573931.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009573932_009594945.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009573932_009594945.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009594946_009615267.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009594946_009615267.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009615268_009638169.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009615268_009638169.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009638170_009662213.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009638170_009662213.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009662214_009685662.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009662214_009685662.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009685663_009709679.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009685663_009709679.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009709680_009734678.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009709680_009734678.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009734679_009757942.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009734679_009757942.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009757943_009783862.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009757943_009783862.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009783863_009809953.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009783863_009809953.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009809954_009836218.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009809954_009836218.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009836219_009863257.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009836219_009863257.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009863258_009890708.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009863258_009890708.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009890709_009917463.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009890709_009917463.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009917464_009941759.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009917464_009941759.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009941760_009966738.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009941760_009966738.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009966739_009994515.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009966739_009994515.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009994516_010023714.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_009994516_010023714.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010023715_010054350.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010023715_010054350.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010054351_010082208.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010054351_010082208.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010082209_010109610.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010082209_010109610.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010109611_010138916.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010109611_010138916.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010138917_010164423.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010138917_010164423.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010164424_010189040.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010164424_010189040.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010189041_010213534.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010189041_010213534.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010213535_010238275.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010213535_010238275.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010238276_010267391.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010238276_010267391.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010267392_010300217.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010267392_010300217.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010300218_010336418.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010300218_010336418.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010336419_010370470.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010336419_010370470.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010370471_010402493.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010370471_010402493.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010402494_010430531.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010402494_010430531.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010430532_010460225.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010430532_010460225.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010460226_010489050.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010460226_010489050.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010489051_010514077.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010489051_010514077.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010514078_010540961.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010514078_010540961.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010540962_010568539.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010540962_010568539.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010568540_010596152.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010568540_010596152.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010596153_010624376.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010596153_010624376.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010624377_010654109.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010624377_010654109.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010654110_010684105.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010654110_010684105.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010684106_010712580.sql
+++ b/models/silver/streamline/decoder/history/range_1/streamline__decode_logs_history_010684106_010712580.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010712581_010745637.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010712581_010745637.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010745638_010777600.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010745638_010777600.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010777601_010816048.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010777601_010816048.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010816049_010857380.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010816049_010857380.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010857381_010900388.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010857381_010900388.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010900389_010938685.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010900389_010938685.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010938686_010974843.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010938686_010974843.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010974844_011012975.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_010974844_011012975.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011012976_011048651.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011012976_011048651.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011048652_011082048.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011048652_011082048.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011082049_011115088.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011082049_011115088.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011115089_011148777.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011115089_011148777.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011148778_011181879.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011148778_011181879.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011181880_011220572.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011181880_011220572.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011220573_011259847.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011220573_011259847.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011259848_011298566.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011259848_011298566.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011298567_011337241.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011298567_011337241.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011337242_011370669.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011337242_011370669.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011370670_011404263.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011370670_011404263.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011404264_011439927.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011404264_011439927.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011439928_011475675.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011439928_011475675.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011475676_011509050.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011475676_011509050.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011509051_011539579.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011509051_011539579.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011539580_011568030.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011539580_011568030.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011568031_011597942.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011568031_011597942.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011597943_011628068.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011597943_011628068.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011628069_011657604.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011628069_011657604.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011657605_011685236.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011657605_011685236.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011685237_011712078.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011685237_011712078.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011712079_011738416.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011712079_011738416.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011738417_011764646.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011738417_011764646.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011764647_011791936.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011764647_011791936.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011791937_011821664.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011791937_011821664.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011821665_011852417.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011821665_011852417.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011852418_011879368.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011852418_011879368.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011879369_011903401.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011879369_011903401.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011903402_011925974.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011903402_011925974.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011925975_011950140.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011925975_011950140.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011950141_011972511.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011950141_011972511.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011972512_011997459.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011972512_011997459.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011997460_012024286.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_011997460_012024286.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012024287_012052517.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012024287_012052517.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012052518_012080292.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012052518_012080292.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012080293_012104460.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012080293_012104460.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012104461_012124402.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012104461_012124402.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012124403_012144601.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012124403_012144601.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012144602_012164633.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012144602_012164633.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012164634_012182580.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012164634_012182580.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012182581_012199123.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012182581_012199123.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012199124_012217751.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012199124_012217751.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012217752_012234998.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012217752_012234998.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012234999_012254195.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012234999_012254195.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012254196_012273965.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012254196_012273965.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012273966_012289083.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012273966_012289083.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012289084_012305091.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012289084_012305091.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012305092_012319554.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012305092_012319554.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012319555_012335557.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012319555_012335557.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012335559_012351126.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012335559_012351126.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012351127_012365674.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012351127_012365674.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012365675_012385593.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012365675_012385593.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012385594_012402222.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012385594_012402222.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012402223_012420384.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012402223_012420384.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012420385_012438856.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012420385_012438856.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012438857_012455237.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012438857_012455237.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012455238_012474959.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012455238_012474959.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012474960_012492604.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012474960_012492604.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012492605_012509382.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012492605_012509382.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012509383_012527726.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012509383_012527726.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012527727_012542539.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012527727_012542539.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012542540_012560337.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012542540_012560337.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012560338_012576417.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012560338_012576417.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012576418_012591814.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012576418_012591814.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012591815_012610844.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012591815_012610844.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012610845_012626350.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012610845_012626350.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012626351_012644403.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012626351_012644403.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012644404_012660127.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012644404_012660127.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012660128_012674157.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012660128_012674157.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012674158_012688986.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012674158_012688986.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012688987_012701668.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012688987_012701668.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012701669_012717283.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012701669_012717283.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012717284_012730926.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012717284_012730926.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012730927_012746160.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012730927_012746160.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012746161_012759788.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012746161_012759788.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012759789_012775613.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012759789_012775613.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012775614_012788825.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012775614_012788825.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012788826_012804068.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012788826_012804068.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012804069_012817434.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012804069_012817434.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012817435_012833551.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012817435_012833551.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012833552_012847718.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012833552_012847718.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012847719_012862782.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012847719_012862782.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012862783_012876387.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012862783_012876387.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012876388_012890210.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012876388_012890210.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012890211_012903305.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012890211_012903305.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012903306_012917556.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012903306_012917556.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012917557_012930681.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012917557_012930681.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012930682_012944185.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012930682_012944185.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012944186_012956746.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012944186_012956746.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012956747_012970463.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012956747_012970463.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012970464_012983839.sql
+++ b/models/silver/streamline/decoder/history/range_2/streamline__decode_logs_history_012970464_012983839.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_012983841_012997066.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_012983841_012997066.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_012997067_013010157.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_012997067_013010157.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013010158_013024134.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013010158_013024134.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013024135_013037470.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013024135_013037470.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013037471_013051381.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013037471_013051381.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013051382_013065165.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013051382_013065165.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013065166_013079330.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013065166_013079330.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013079331_013094545.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013079331_013094545.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013094546_013108222.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013094546_013108222.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013108223_013124654.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013108223_013124654.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013124655_013141845.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013124655_013141845.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013141846_013161275.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013141846_013161275.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013161276_013186250.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013161276_013186250.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013186251_013209379.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013186251_013209379.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013209380_013229685.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013209380_013229685.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013229686_013248231.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013229686_013248231.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013248232_013269341.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013248232_013269341.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013269342_013287471.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013269342_013287471.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013287472_013306084.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013287472_013306084.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013306085_013330252.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013306085_013330252.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013330253_013355284.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013330253_013355284.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013355285_013382952.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013355285_013382952.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013382953_013413784.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013382953_013413784.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013413785_013443168.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013413785_013443168.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013443169_013469981.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013443169_013469981.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013469982_013497779.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013469982_013497779.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013497780_013526604.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013497780_013526604.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013526605_013555064.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013526605_013555064.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013555065_013584177.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013555065_013584177.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013584178_013615306.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013584178_013615306.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013615307_013645016.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013615307_013645016.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013645017_013670232.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013645017_013670232.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013670233_013696899.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013670233_013696899.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013696900_013724698.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013696900_013724698.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013724699_013751195.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013724699_013751195.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013751196_013783704.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013751196_013783704.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013783705_013815669.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013783705_013815669.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013815670_013843985.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013815670_013843985.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013843986_013871710.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013843986_013871710.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013871711_013900404.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013871711_013900404.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013900405_013929581.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013900405_013929581.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013929582_013959249.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013929582_013959249.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013959250_013993859.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013959250_013993859.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013993860_014025601.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_013993860_014025601.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014025602_014053050.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014025602_014053050.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014053051_014080664.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014053051_014080664.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014080665_014108152.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014080665_014108152.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014108153_014135911.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014108153_014135911.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014135912_014165849.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014135912_014165849.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014165850_014199047.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014165850_014199047.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014199048_014234482.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014199048_014234482.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014234483_014264629.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014234483_014264629.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014264630_014295983.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014264630_014295983.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014295984_014326937.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014295984_014326937.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014326938_014357460.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014326938_014357460.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014357461_014389176.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014357461_014389176.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014389177_014421370.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014389177_014421370.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014421371_014452829.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014421371_014452829.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014452830_014481320.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014452830_014481320.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014481321_014515659.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014481321_014515659.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014515660_014546915.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014515660_014546915.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014546916_014578119.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014546916_014578119.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014578120_014612945.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014578120_014612945.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014612946_014649421.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014612946_014649421.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014649422_014685054.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014649422_014685054.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014685055_014719979.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014685055_014719979.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014719980_014757426.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014719980_014757426.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014757427_014793924.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014757427_014793924.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014793925_014837231.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014793925_014837231.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014837232_014876022.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014837232_014876022.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014876023_014908377.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014876023_014908377.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014908378_014947110.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014908378_014947110.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014947111_014978072.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014947111_014978072.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014978073_015007055.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_014978073_015007055.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015007056_015038043.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015007056_015038043.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015038044_015065941.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015038044_015065941.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015065942_015096241.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015065942_015096241.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015096242_015128219.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015096242_015128219.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015128220_015157433.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015128220_015157433.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015157434_015188142.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015157434_015188142.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015188143_015220844.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015188143_015220844.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015220845_015251955.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015220845_015251955.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015251956_015280630.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015251956_015280630.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015280631_015309696.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015280631_015309696.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015309697_015340495.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015309697_015340495.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015340496_015371244.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015340496_015371244.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015371245_015407435.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015371245_015407435.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015407436_015442992.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015407436_015442992.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015442993_015476219.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015442993_015476219.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015476220_015508193.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015476220_015508193.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015508194_015538840.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015508194_015538840.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015538841_015572578.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015538841_015572578.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015572579_015612639.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015572579_015612639.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015612640_015651958.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015612640_015651958.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015651959_015686158.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015651959_015686158.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015686159_015726869.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015686159_015726869.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015726870_015765072.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015726870_015765072.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015765073_015803326.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015765073_015803326.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015803327_015846281.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015803327_015846281.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015846282_015882486.sql
+++ b/models/silver/streamline/decoder/history/range_3/streamline__decode_logs_history_015846282_015882486.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_015882487_015922392.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_015882487_015922392.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_015922393_015962069.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_015922393_015962069.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_015962070_016000793.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_015962070_016000793.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016000794_016044344.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016000794_016044344.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016044345_016082050.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016044345_016082050.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016082051_016119169.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016082051_016119169.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016119170_016157092.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016119170_016157092.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016157093_016194645.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016157093_016194645.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016194646_016229386.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016194646_016229386.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016229387_016266062.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016229387_016266062.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016266063_016300278.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016266063_016300278.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016300279_016335318.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016300279_016335318.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016335319_016369354.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016335319_016369354.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016369355_016410416.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016369355_016410416.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016410417_016448088.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016410417_016448088.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016448089_016482292.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016448089_016482292.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016482293_016515564.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016482293_016515564.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016515565_016550457.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016515565_016550457.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016550458_016583593.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016550458_016583593.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016583594_016618226.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016583594_016618226.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016618227_016651901.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016618227_016651901.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016651902_016683736.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016651902_016683736.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016683737_016716965.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016683737_016716965.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016716966_016753876.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016716966_016753876.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016753877_016792062.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016753877_016792062.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016792063_016834070.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016792063_016834070.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016834071_016876937.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016834071_016876937.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016876938_016917348.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016876938_016917348.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016917349_016965189.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016917349_016965189.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016965190_017011586.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_016965190_017011586.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017011587_017054843.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017011587_017054843.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017054844_017098298.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017054844_017098298.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017098299_017135508.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017098299_017135508.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017135509_017169538.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017135509_017169538.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017169539_017197431.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017169539_017197431.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017197432_017230789.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017197432_017230789.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017230790_017269681.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017230790_017269681.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017269682_017310202.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017269682_017310202.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017310203_017348191.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017310203_017348191.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017348192_017386899.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017348192_017386899.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017386900_017427785.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017386900_017427785.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017427786_017475801.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017427786_017475801.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017475802_017521450.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017475802_017521450.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017521451_017567023.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017521451_017567023.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017567024_017615186.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017567024_017615186.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017615187_017657909.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017615187_017657909.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017657910_017700752.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017657910_017700752.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017700753_017730994.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017700753_017730994.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017730995_017759558.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017730995_017759558.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017759559_017793794.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017759559_017793794.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017793795_017835353.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017793795_017835353.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017835354_017879762.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017835354_017879762.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017879763_017927306.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017879763_017927306.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017927307_017972339.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017927307_017972339.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017972340_018025505.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_017972340_018025505.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018025506_018073509.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018025506_018073509.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018073510_018117143.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018073510_018117143.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018117144_018163988.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018117144_018163988.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018163989_018215320.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018163989_018215320.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018215321_018263090.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018215321_018263090.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018263091_018311299.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018263091_018311299.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018311300_018363250.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018311300_018363250.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018363251_018418487.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018363251_018418487.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018418488_018466894.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018418488_018466894.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018466895_018512284.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018466895_018512284.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018512285_018562376.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018512285_018562376.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018562377_018614042.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018562377_018614042.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018614043_018659796.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018614043_018659796.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018659797_018708752.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018659797_018708752.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018708753_018760323.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018708753_018760323.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018760324_018818515.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018760324_018818515.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018818516_018874234.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018818516_018874234.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018874235_018929497.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018874235_018929497.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018929498_018985382.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018929498_018985382.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018985383_019044053.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_018985383_019044053.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019044054_019099785.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019044054_019099785.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019099786_019150428.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019099786_019150428.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019150429_019206779.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019150429_019206779.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019206780_019266633.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019206780_019266633.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019266634_019320041.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019266634_019320041.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019320042_019373887.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019320042_019373887.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019373888_019436203.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019373888_019436203.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019436204_019490083.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019436204_019490083.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019490084_019546009.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019490084_019546009.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019546010_019601584.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019546010_019601584.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019601585_019657895.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019601585_019657895.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019657896_019712314.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019657896_019712314.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019712315_019769409.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019712315_019769409.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019769410_019832009.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019769410_019832009.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019832010_019891273.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019832010_019891273.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019891274_019946430.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019891274_019946430.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019946431_020002880.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_019946431_020002880.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020002881_020057236.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020002881_020057236.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020057237_020115218.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020057237_020115218.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020115219_020174517.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020115219_020174517.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020174518_020233397.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020174518_020233397.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020233398_020291143.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020233398_020291143.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020291144_020345943.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020291144_020345943.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020345944_020403414.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020345944_020403414.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020403415_020463481.sql
+++ b/models/silver/streamline/decoder/history/range_4/streamline__decode_logs_history_020403415_020463481.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020463482_020521743.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020463482_020521743.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020521744_020581144.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020521744_020581144.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020581145_020655539.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020581145_020655539.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020655540_020722287.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020655540_020722287.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020722288_020791134.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020722288_020791134.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020791135_020866520.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020791135_020866520.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020866521_020931541.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020866521_020931541.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020931542_020997271.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020931542_020997271.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020997272_021066767.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_020997272_021066767.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021066768_021125849.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021066768_021125849.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021125850_021179689.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021125850_021179689.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021179690_021243768.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021179690_021243768.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021243769_021312563.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021243769_021312563.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021312564_021375232.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021312564_021375232.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021375233_021440764.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021375233_021440764.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021440765_021508422.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021440765_021508422.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021508423_021579451.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021508423_021579451.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021579452_021658590.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021579452_021658590.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021658591_021727042.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021658591_021727042.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021727043_021802217.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021727043_021802217.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021802218_021883695.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021802218_021883695.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021883696_021956020.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021883696_021956020.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021956021_022035741.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_021956021_022035741.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022035742_022106970.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022035742_022106970.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022106971_022164794.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022106971_022164794.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022164795_022238418.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022164795_022238418.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022238419_022303287.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022238419_022303287.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022303288_022367541.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022303288_022367541.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022367542_022440173.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022367542_022440173.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022440174_022507261.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022440174_022507261.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022507262_022574053.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022507262_022574053.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022574054_022641294.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022574054_022641294.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022641295_022699154.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022641295_022699154.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022699155_022755724.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022699155_022755724.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022755725_022813768.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022755725_022813768.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022813769_022875715.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022813769_022875715.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022875716_022926035.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022875716_022926035.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022926036_022986886.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022926036_022986886.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022986887_023049767.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_022986887_023049767.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023049768_023115721.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023049768_023115721.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023115722_023187635.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023115722_023187635.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023187636_023250265.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023187636_023250265.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023250266_023319917.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023250266_023319917.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023319918_023391932.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023319918_023391932.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023391933_023464406.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023391933_023464406.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023464407_023531481.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023464407_023531481.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023531482_023596675.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023531482_023596675.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023596676_023670873.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023596676_023670873.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023670874_023736045.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023670874_023736045.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023736046_023812035.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023736046_023812035.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023812036_023883218.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023812036_023883218.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023883219_023950557.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023883219_023950557.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023950558_024024494.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_023950558_024024494.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024024495_024097813.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024024495_024097813.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024097814_024178554.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024097814_024178554.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024178555_024262515.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024178555_024262515.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024262516_024341947.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024262516_024341947.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024341948_024423728.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024341948_024423728.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024423729_024501288.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024423729_024501288.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024501289_024580027.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024501289_024580027.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024580028_024652973.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024580028_024652973.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024652974_024722457.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024652974_024722457.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024722458_024790772.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024722458_024790772.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024790773_024863299.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024790773_024863299.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024863300_024930895.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024863300_024930895.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024930896_024981819.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024930896_024981819.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024981820_025041396.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_024981820_025041396.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025041397_025097997.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025041397_025097997.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025097998_025152439.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025097998_025152439.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025152440_025210119.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025152440_025210119.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025210120_025265448.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025210120_025265448.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025265449_025318500.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025265449_025318500.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025318501_025376049.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025318501_025376049.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025376050_025430233.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025376050_025430233.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025430234_025484270.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025430234_025484270.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025484271_025536639.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025484271_025536639.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025536640_025593329.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025536640_025593329.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025593330_025652223.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025593330_025652223.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025652224_025705664.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025652224_025705664.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025705665_025751541.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025705665_025751541.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025751542_025800127.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025751542_025800127.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025800128_025839360.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025800128_025839360.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025839361_025885670.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025839361_025885670.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025885671_025940312.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025885671_025940312.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025940313_026003232.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_025940313_026003232.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026003233_026063750.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026003233_026063750.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026063751_026121056.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026063751_026121056.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026121057_026186105.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026121057_026186105.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026186106_026252653.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026186106_026252653.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026252654_026315880.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026252654_026315880.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026315881_026372545.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026315881_026372545.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026372546_026432160.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026372546_026432160.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026432161_026491196.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026432161_026491196.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026491197_026542886.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026491197_026542886.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026542887_026604156.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026542887_026604156.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026604157_026666830.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026604157_026666830.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026666831_026727828.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026666831_026727828.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026727829_026801269.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026727829_026801269.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026801270_026871152.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026801270_026871152.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026871153_026941203.sql
+++ b/models/silver/streamline/decoder/history/range_5/streamline__decode_logs_history_026871153_026941203.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_026941204_027011940.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_026941204_027011940.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027011941_027079843.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027011941_027079843.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027079844_027151169.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027079844_027151169.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027151170_027227077.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027151170_027227077.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027227078_027295914.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027227078_027295914.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027295915_027361848.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027295915_027361848.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027361849_027426044.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027361849_027426044.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027426045_027496045.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027426045_027496045.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027496046_027566046.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027496046_027566046.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027566047_027636047.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027566047_027636047.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027636048_027706048.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027636048_027706048.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027706049_027776049.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027706049_027776049.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027776050_027846050.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027776050_027846050.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027846051_027916051.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027846051_027916051.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027916052_027986052.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027916052_027986052.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027986053_028056053.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_027986053_028056053.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028056054_028126054.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028056054_028126054.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028126055_028196055.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028126055_028196055.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028196056_028266056.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028196056_028266056.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028266057_028336057.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028266057_028336057.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028336058_028406058.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028336058_028406058.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028406059_028476059.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028406059_028476059.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028476060_028546060.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028476060_028546060.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028546061_028616061.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028546061_028616061.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028616062_028686062.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028616062_028686062.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028686063_028756063.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028686063_028756063.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028756064_028826064.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028756064_028826064.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028826065_028896065.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028826065_028896065.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028896066_028966066.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028896066_028966066.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028966067_029036067.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_028966067_029036067.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029036068_029106068.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029036068_029106068.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029106069_029176069.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029106069_029176069.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029176070_029246070.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029176070_029246070.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029246071_029316071.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029246071_029316071.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029316072_029386072.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029316072_029386072.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029386073_029456073.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029386073_029456073.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029456074_029526074.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029456074_029526074.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029526075_029596075.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029526075_029596075.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029596076_029666076.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029596076_029666076.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029666077_029736077.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029666077_029736077.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029736078_029806078.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029736078_029806078.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029806079_029876079.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029806079_029876079.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029876080_029946080.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029876080_029946080.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029946081_030016081.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_029946081_030016081.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030016082_030086082.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030016082_030086082.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030086083_030156083.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030086083_030156083.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030156084_030226084.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030156084_030226084.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030226085_030296085.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030226085_030296085.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030296086_030366086.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030296086_030366086.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030366087_030436087.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030366087_030436087.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030436088_030506088.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030436088_030506088.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030506089_030576089.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030506089_030576089.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030576090_030646090.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030576090_030646090.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030646091_030716091.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030646091_030716091.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030716092_030786092.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030716092_030786092.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030786093_030856093.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030786093_030856093.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030856094_030926094.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030856094_030926094.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030926095_030996095.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030926095_030996095.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030996096_031066096.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_030996096_031066096.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031066097_031136097.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031066097_031136097.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031136098_031206098.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031136098_031206098.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031206099_031276099.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031206099_031276099.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031276100_031346100.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031276100_031346100.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031346101_031416101.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031346101_031416101.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031416102_031486102.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031416102_031486102.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031486103_031556103.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031486103_031556103.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031556104_031626104.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031556104_031626104.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031626105_031696105.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031626105_031696105.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031696106_031766106.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031696106_031766106.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031766107_031836107.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031766107_031836107.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031836108_031906108.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031836108_031906108.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031906109_031976109.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031906109_031976109.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031976110_032000000.sql
+++ b/models/silver/streamline/decoder/history/range_6/streamline__decode_logs_history_031976110_032000000.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()]
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ decode_logs_history(
+    start,
+    stop
+) }}


### PR DESCRIPTION
- adds 570+ history files to decode history, starting with a 7.5m limit
- adds manual jobs for backfill
- removes history from regular incremental