### PR TITLE
add confirm blocks model

### DIFF
--- a/models/bronze/core/bronze__streamline_FR_confirm_blocks.sql
+++ b/models/bronze/core/bronze__streamline_FR_confirm_blocks.sql
@@ -1,0 +1,9 @@
+{{ config (
+    materialized = 'view'
+) }}
+{{ streamline_external_table_FR_query(
+    model = "confirm_blocks",
+    partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 4), '_', 1) AS INTEGER )",
+    partition_name = "_partition_by_block_id",
+    unique_key = "block_number"
+) }}

--- a/models/bronze/core/bronze__streamline_confirm_blocks.sql
+++ b/models/bronze/core/bronze__streamline_confirm_blocks.sql
@@ -1,0 +1,9 @@
+{{ config (
+    materialized = 'view'
+) }}
+{{ streamline_external_table_query(
+    model = "confirm_blocks",
+    partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 4), '_', 1) AS INTEGER )",
+    partition_name = "_partition_by_block_id",
+    unique_key = "block_number"
+) }}

--- a/models/silver/core/silver__confirmed_blocks.sql
+++ b/models/silver/core/silver__confirmed_blocks.sql
@@ -1,0 +1,49 @@
+-- depends_on: {{ ref('bronze__streamline_confirm_blocks') }}
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = "round(block_number,-3)"
+) }}
+
+WITH base AS (
+
+    SELECT
+        block_number,
+        DATA :result :hash :: STRING AS block_hash,
+        DATA :result :transactions txs,
+        _inserted_timestamp
+    FROM
+
+{% if is_incremental() %}
+{{ ref('bronze__streamline_confirm_blocks') }}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            IFNULL(
+                MAX(
+                    _inserted_timestamp
+                ),
+                '1970-01-01' :: TIMESTAMP
+            ) _inserted_timestamp
+        FROM
+            {{ this }}
+    )
+{% else %}
+    {{ ref('bronze__streamline_FR_confirm_blocks') }}
+{% endif %}
+
+qualify(ROW_NUMBER() over (PARTITION BY block_number
+ORDER BY
+    _inserted_timestamp DESC)) = 1
+)
+SELECT
+    block_number,
+    block_hash,
+    VALUE :: STRING AS tx_hash,
+    _inserted_timestamp
+FROM
+    base,
+    LATERAL FLATTEN (
+        input => txs
+    )

--- a/models/silver/streamline/_max_block_by_hour.sql
+++ b/models/silver/streamline/_max_block_by_hour.sql
@@ -1,0 +1,37 @@
+{{ config (
+    materialized = "ephemeral"
+) }}
+
+WITH base AS (
+
+    SELECT
+        DATE_TRUNC(
+            'hour',
+            block_timestamp
+        ) AS block_hour,
+        MAX(block_number) block_number
+    FROM
+        {{ ref("silver__blocks") }}
+    WHERE
+        block_timestamp > DATEADD(
+            'day',
+            -3,
+            CURRENT_DATE
+        )
+    GROUP BY
+        1
+)
+SELECT
+    block_hour,
+    block_number
+FROM
+    base
+WHERE
+    block_hour <> (
+        SELECT
+            MAX(
+                block_hour
+            )
+        FROM
+            base
+    )

--- a/models/silver/streamline/core/complete/streamline__complete_confirmed_blocks.sql
+++ b/models/silver/streamline/core/complete/streamline__complete_confirmed_blocks.sql
@@ -1,0 +1,28 @@
+-- depends_on: {{ ref('bronze__streamline_confirm_blocks') }}
+{{ config (
+    materialized = "incremental",
+    unique_key = "id",
+    cluster_by = "ROUND(block_number, -3)"
+) }}
+
+SELECT
+    id,
+    block_number,
+    _inserted_timestamp
+FROM
+
+{% if is_incremental() %}
+{{ ref('bronze__streamline_confirm_blocks') }}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            COALESCE(MAX(_inserted_timestamp), '1970-01-01' :: TIMESTAMP) _inserted_timestamp
+        FROM
+            {{ this }})
+        {% else %}
+            {{ ref('bronze__streamline_FR_confirm_blocks') }}
+        {% endif %}
+
+        qualify(ROW_NUMBER() over (PARTITION BY id
+        ORDER BY
+            _inserted_timestamp DESC)) = 1

--- a/models/silver/streamline/core/realtime/streamline__confirm_blocks_realtime.sql
+++ b/models/silver/streamline/core/realtime/streamline__confirm_blocks_realtime.sql
@@ -1,0 +1,62 @@
+{{ config (
+    materialized = "view",
+    post_hook = if_data_call_function(
+        func = "{{this.schema}}.udf_json_rpc(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'confirm_blocks', 'method', 'eth_getBlockByNumber', 'producer_batch_size',5000, 'producer_limit_size', 5000000, 'worker_batch_size',500))",
+        target = "{{this.schema}}.{{this.identifier}}"
+    )
+) }}
+
+WITH look_back AS (
+
+    SELECT
+        block_number
+    FROM
+        {{ ref("_max_block_by_hour") }}
+        qualify ROW_NUMBER() over (
+            ORDER BY
+                block_number DESC
+        ) = 6
+),
+tbl AS (
+    SELECT
+        block_number
+    FROM
+        {{ ref("streamline__blocks") }}
+    WHERE
+        block_number IS NOT NULL
+        AND block_number <= (
+            SELECT
+                block_number
+            FROM
+                look_back
+        )
+    EXCEPT
+    SELECT
+        block_number
+    FROM
+        {{ ref("streamline__complete_confirmed_blocks") }}
+    WHERE
+        block_number IS NOT NULL
+        AND block_number <= (
+            SELECT
+                block_number
+            FROM
+                look_back
+        )
+)
+SELECT
+    block_number,
+    'eth_getBlockByNumber' AS method,
+    CONCAT(
+        REPLACE(
+            concat_ws('', '0x', to_char(block_number, 'XXXXXXXX')),
+            ' ',
+            ''
+        ),
+        '_-_',
+        'false'
+    ) AS params
+FROM
+    tbl
+ORDER BY
+    block_number ASC

--- a/models/silver/streamline/core/realtime/streamline__receipts_realtime.sql
+++ b/models/silver/streamline/core/realtime/streamline__receipts_realtime.sql
@@ -24,7 +24,7 @@ WITH tbl AS (
             ''
         ) AS block_number_hex
     FROM
-        {{ ref("streamline__complete_blocks") }}
+        {{ ref("streamline__complete_receipts") }}
     WHERE
         block_number IS NOT NULL
 ),

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -56,3 +56,4 @@ sources:
       - name: receipts
       - name: traces
       - name: decoded_logs
+      - name: confirm_blocks


### PR DESCRIPTION
- adds model for a secondary blocks call further off chainhead for testing purposes 