### PR TITLE
precise columns

### DIFF
--- a/models/doc_descriptions/general/precise_amounts.md
+++ b/models/doc_descriptions/general/precise_amounts.md
@@ -1,0 +1,17 @@
+{% docs precise_amount_unadjusted %}
+
+The precise, unadjusted amount of the transaction. This is returned as a string to avoid precision loss. 
+
+{% enddocs %}
+
+{% docs precise_amount_adjusted %}
+
+The precise, adjusted amount of the transaction. This is returned as a string to avoid precision loss. 
+
+{% enddocs %}
+
+{% docs tx_fee_precise %}
+
+The precise amount of the transaction fee. This is returned as a string to avoid precision loss. 
+
+{% enddocs %}

--- a/models/gold/core/core__ez_bnb_transfers.sql
+++ b/models/gold/core/core__ez_bnb_transfers.sql
@@ -1,37 +1,110 @@
 {{ config(
-    materialized = 'view',
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['core','non_realtime'],
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}
 
+WITH bnb_base AS (
+
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        identifier,
+        from_address,
+        to_address,
+        bnb_value,
+        _call_id,
+        _inserted_timestamp,
+        to_varchar(
+            TO_NUMBER(REPLACE(DATA :value :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :value :: STRING, '0x'))))
+        ) AS bnb_value_precise_raw,
+        IFF(LENGTH(bnb_value_precise_raw) > 18, LEFT(bnb_value_precise_raw, LENGTH(bnb_value_precise_raw) - 18) || '.' || RIGHT(bnb_value_precise_raw, 18), '0.' || LPAD(bnb_value_precise_raw, 18, '0')) AS rough_conversion,
+        IFF(
+            POSITION(
+                '.000000000000000000' IN rough_conversion
+            ) > 0,
+            LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
+            REGEXP_REPLACE(
+                rough_conversion,
+                '0*$',
+                ''
+            )
+        ) AS bnb_value_precise
+    FROM
+        {{ ref('silver__traces') }}
+    WHERE
+        bnb_value > 0
+        AND tx_status = 'SUCCESS'
+        AND trace_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+tx_table AS (
+    SELECT
+        block_number,
+        tx_hash,
+        from_address AS origin_from_address,
+        to_address AS origin_to_address,
+        origin_function_signature
+    FROM
+        {{ ref('silver__transactions') }}
+    WHERE
+        tx_hash IN (
+            SELECT
+                DISTINCT tx_hash
+            FROM
+                bnb_base
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
 SELECT
-    A.tx_hash AS tx_hash,
-    A.block_number AS block_number,
-    A.block_timestamp AS block_timestamp,
-    A.identifier AS identifier,
-    tx.from_address AS origin_from_address,
-    tx.to_address AS origin_to_address,
-    tx.origin_function_signature AS origin_function_signature,
-    A.from_address AS bnb_from_address,
-    A.to_address AS bnb_to_address,
-    A.bnb_value AS amount,
+    tx_hash AS tx_hash,
+    block_number AS block_number,
+    block_timestamp AS block_timestamp,
+    identifier AS identifier,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    from_address AS bnb_from_address,
+    to_address AS bnb_to_address,
+    bnb_value AS amount,
+    bnb_value_precise_raw AS amount_precise_raw,
+    bnb_value_precise AS amount_precise,
     ROUND(
-        A.bnb_value * price,
+        bnb_value * price,
         2
-    ) AS amount_usd
+    ) AS amount_usd,
+    _call_id,
+    _inserted_timestamp
 FROM
-    {{ ref('silver__traces') }} A
+    bnb_base A
     LEFT JOIN {{ ref('silver__prices') }}
     ON DATE_TRUNC(
         'hour',
         A.block_timestamp
     ) = HOUR
     AND token_address = LOWER('0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c')
-    JOIN {{ ref('silver__transactions') }}
-    tx
-    ON A.block_timestamp :: DATE = tx.block_timestamp :: DATE
-    AND A.tx_hash = tx.tx_hash
-WHERE
-    A.bnb_value > 0
-    AND A.tx_status = 'SUCCESS'
-    AND A.trace_status = 'SUCCESS'
+    JOIN tx_table USING (
+        tx_hash,
+        block_number
+    )

--- a/models/gold/core/core__ez_bnb_transfers.yml
+++ b/models/gold/core/core__ez_bnb_transfers.yml
@@ -10,9 +10,9 @@ models:
         description: '{{ doc("bsc_block_timestamp") }}'
       - name: TX_HASH
         description: '{{ doc("bsc_transfer_tx_hash") }}'
-      - name: ETH_FROM_ADDRESS
+      - name: BNB_FROM_ADDRESS
         description: '{{ doc("bsc_transfer_from_address") }}'
-      - name: ETH_TO_ADDRESS
+      - name: BNB_TO_ADDRESS
         description: '{{ doc("bsc_transfer_to_address") }}'
       - name: AMOUNT
         description: '{{ doc("bsc_eth_amount") }}'
@@ -30,3 +30,7 @@ models:
         description: '{{ doc("bsc_origin_to") }}'
       - name: IDENTIFIER
         description: '{{ doc("bsc_traces_identifier") }}'
+      - name: AMOUNT_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: AMOUNT_PRECISE
+        description: '{{ doc("precise_amount_adjusted") }}'

--- a/models/gold/core/core__ez_token_transfers.sql
+++ b/models/gold/core/core__ez_token_transfers.sql
@@ -15,6 +15,7 @@ SELECT
     from_address,
     to_address,
     raw_amount,
+    raw_amount_precise,
     C.token_decimals AS decimals,
     C.token_symbol AS symbol,
     price AS token_price,

--- a/models/gold/core/core__ez_token_transfers.yml
+++ b/models/gold/core/core__ez_token_transfers.yml
@@ -40,3 +40,5 @@ models:
         description: '{{ doc("bsc_origin_from") }}'
       - name: ORIGIN_TO_ADDRESS
         description: '{{ doc("bsc_origin_to") }}'
+      - name: RAW_AMOUNT_PRECISE
+        description: '{{ doc("precise_amount_unadjusted") }}'

--- a/models/gold/core/core__fact_token_transfers.sql
+++ b/models/gold/core/core__fact_token_transfers.sql
@@ -15,6 +15,7 @@ SELECT
     from_address,
     to_address,
     raw_amount,
+    raw_amount_precise,
     _log_id
 FROM
     {{ ref('silver__transfers') }}

--- a/models/gold/core/core__fact_token_transfers.yml
+++ b/models/gold/core/core__fact_token_transfers.yml
@@ -18,6 +18,8 @@ models:
         description: '{{ doc("bsc_transfer_to_address") }}'
       - name: RAW_AMOUNT
         description: '{{ doc("bsc_transfer_raw_amount") }}'
+      - name: RAW_AMOUNT_PRECISE
+        description: '{{ doc("precise_amount_unadjusted") }}'
       - name: _LOG_ID
         description: '{{ doc("bsc_log_id_transfers") }}'
       - name: ORIGIN_FUNCTION_SIGNATURE

--- a/models/gold/core/core__fact_traces.sql
+++ b/models/gold/core/core__fact_traces.sql
@@ -11,6 +11,14 @@ SELECT
     from_address,
     to_address,
     bnb_value,
+    IFNULL(
+        bnb_value_precise_raw,
+        '0'
+    ) AS bnb_value_precise_raw,
+    IFNULL(
+        bnb_value_precise,
+        '0'
+    ) AS bnb_value_precise,
     gas,
     gas_used,
     input,
@@ -24,4 +32,46 @@ SELECT
     error_reason,
     trace_index
 FROM
-    {{ ref('silver__traces') }}
+    (
+        SELECT
+            tx_hash,
+            block_number,
+            block_timestamp,
+            from_address,
+            to_address,
+            bnb_value,
+            gas,
+            gas_used,
+            input,
+            output,
+            TYPE,
+            identifier,
+            DATA,
+            tx_status,
+            sub_traces,
+            trace_status,
+            error_reason,
+            trace_index,
+            REPLACE(
+                COALESCE(
+                    DATA :value :: STRING,
+                    DATA :action :value :: STRING
+                ),
+                '0x'
+            ) AS hex,
+            to_varchar(TO_NUMBER(hex, REPEAT('X', LENGTH(hex)))) AS bnb_value_precise_raw,
+            IFF(LENGTH(bnb_value_precise_raw) > 18, LEFT(bnb_value_precise_raw, LENGTH(bnb_value_precise_raw) - 18) || '.' || RIGHT(bnb_value_precise_raw, 18), '0.' || LPAD(bnb_value_precise_raw, 18, '0')) AS rough_conversion,
+            IFF(
+                POSITION(
+                    '.000000000000000000' IN rough_conversion
+                ) > 0,
+                LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
+                REGEXP_REPLACE(
+                    rough_conversion,
+                    '0*$',
+                    ''
+                )
+            ) AS bnb_value_precise
+        FROM
+            {{ ref('silver__traces') }}
+    )

--- a/models/gold/core/core__fact_traces.yml
+++ b/models/gold/core/core__fact_traces.yml
@@ -16,6 +16,10 @@ models:
         description: '{{ doc("bsc_traces_to") }}'
       - name: BNB_VALUE
         description: '{{ doc("bsc_traces_value") }}'
+      - name: BNB_VALUE_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: BNB_VALUE_PRECISE
+        description: '{{ doc("precise_amount_adjusted") }}'
       - name: GAS
         description: '{{ doc("bsc_traces_gas") }}'
       - name: GAS_USED

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -14,18 +14,63 @@ SELECT
     origin_function_signature,
     from_address,
     to_address,
-    VALUE AS bnb_value,
+    bnb_value,
+    bnb_value_precise_raw,
+    bnb_value_precise,
     tx_fee,
+    tx_fee_precise,
     gas_price,
-    gas AS gas_limit,
+    gas_limit,
     gas_used,
     cumulative_gas_used,
     input_data,
-    tx_status AS status,
+    status,
     effective_gas_price,
     r,
     s,
     v,
     tx_type
 FROM
-    {{ ref('silver__transactions') }}
+    (
+        SELECT
+            block_number,
+            block_timestamp,
+            block_hash,
+            tx_hash,
+            nonce,
+            POSITION,
+            origin_function_signature,
+            from_address,
+            to_address,
+            VALUE AS bnb_value,
+            tx_fee,
+            tx_fee_precise,
+            gas_price,
+            gas AS gas_limit,
+            gas_used,
+            cumulative_gas_used,
+            input_data,
+            tx_status AS status,
+            effective_gas_price,
+            r,
+            s,
+            v,
+            tx_type,
+            to_varchar(
+                TO_NUMBER(REPLACE(DATA :value :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :value :: STRING, '0x'))))
+            ) AS bnb_value_precise_raw,
+            IFF(LENGTH(bnb_value_precise_raw) > 18, LEFT(bnb_value_precise_raw, LENGTH(bnb_value_precise_raw) - 18) || '.' || RIGHT(bnb_value_precise_raw, 18), '0.' || LPAD(bnb_value_precise_raw, 18, '0')) AS rough_conversion,
+            IFF(
+                POSITION(
+                    '.000000000000000000' IN rough_conversion
+                ) > 0,
+                LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
+                REGEXP_REPLACE(
+                    rough_conversion,
+                    '0*$',
+                    ''
+                )
+            ) AS bnb_value_precise
+        FROM
+            {{ ref('silver__transactions') }}
+    )

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -22,8 +22,14 @@ models:
         description: '{{ doc("bsc_to_address") }}' 
       - name: BNB_VALUE
         description: '{{ doc("bsc_value") }}' 
+      - name: BNB_VALUE_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: BNB_VALUE_PRECISE
+        description: '{{ doc("precise_amount_adjusted") }}'
       - name: TX_FEE
         description: '{{ doc("bsc_tx_fee") }}' 
+      - name: TX_FEE_PRECISE
+        description: '{{ doc("tx_fee_precise") }}' 
       - name: GAS_PRICE
         description: '{{ doc("bsc_tx_gas_price") }}' 
       - name: GAS_LIMIT

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -19,7 +19,8 @@ WITH logs AS (
         contract_address :: STRING AS contract_address,
         CONCAT('0x', SUBSTR(topics [1], 27, 40)) :: STRING AS from_address,
         CONCAT('0x', SUBSTR(topics [2], 27, 40)) :: STRING AS to_address,
-        utils.udf_hex_to_int(SUBSTR(DATA, 3, 64)) :: FLOAT AS raw_amount,
+        utils.udf_hex_to_int(SUBSTR(DATA, 3, 64)) AS raw_amount_precise,
+        raw_amount_precise :: FLOAT AS raw_amount,
         event_index,
         _inserted_timestamp
     FROM
@@ -52,7 +53,8 @@ SELECT
     to_address,
     raw_amount,
     _inserted_timestamp,
-    event_index
+    event_index,
+    raw_amount_precise
 FROM
     logs
 WHERE

--- a/packages.yml
+++ b/packages.yml
@@ -6,4 +6,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.4.1
+    revision: v1.5.0


### PR DESCRIPTION
**`ez_bnb_transfers`**

- converts from view to table for performance gains
- adds `bnb_value_precise`, `bnb_value_precise_raw`, and `_call_id`

**`fact_traces`**

- adds `bnb_value_precise` and `bnb_value_precise_raw`

**`fact_transactions`**

- adds `bnb_value_precise_raw`, `bnb_value_precise`, and `tx_fee_precise`

**`fact_token_transfers`**

- adds `raw_amount_precise`

**`ez_token_transfers`**

- adds `raw_amount_precise`