### PR TITLE
AN-3957/bsc-rpc-fork

### DIFF
--- a/models/doc_descriptions/general/bsc_base_fee_per_gas.md
+++ b/models/doc_descriptions/general/bsc_base_fee_per_gas.md
@@ -1,0 +1,5 @@
+{% docs bsc_base_fee_per_gas %}
+
+A string of the base fee encoded in hexadecimal format. Please note that this response field will not be included in a block requested before the EIP-1559 upgrade.
+
+{% enddocs %}

--- a/models/gold/core/core__fact_blocks.sql
+++ b/models/gold/core/core__fact_blocks.sql
@@ -22,6 +22,8 @@ SELECT
     SIZE,
     uncles AS uncle_blocks,
     OBJECT_CONSTRUCT(
+        'baseFeePerGas',
+        base_fee_per_gas,
         'difficulty',
         difficulty,
         'extraData',

--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -14,6 +14,8 @@ models:
         description: '{{ doc("bsc_blockchain") }}'
       - name: TX_COUNT
         description: '{{ doc("bsc_tx_count") }}'
+      - name: BASE_FEE_PER_GAS
+        description: '{{ doc("bsc_base_fee_per_gas") }}'
       - name: DIFFICULTY
         description: '{{ doc("bsc_difficulty") }}'
       - name: TOTAL_DIFFICULTY

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -54,28 +54,8 @@ FROM
             input_data,
             tx_status AS status,
             effective_gas_price,
-            TO_NUMBER(REPLACE(DATA :maxFeePerGas :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :maxFeePerGas :: STRING, '0x')))) / pow(
-                10,
-                9
-            ) AS max_fee_per_gas,
-            TO_NUMBER(
-                REPLACE(
-                    DATA :maxPriorityFeePerGas :: STRING,
-                    '0x'
-                ),
-                REPEAT(
-                    'X',
-                    LENGTH(
-                        REPLACE(
-                            DATA :maxPriorityFeePerGas :: STRING,
-                            '0x'
-                        )
-                    )
-                )
-            ) / pow(
-                10,
-                9
-            ) AS max_priority_fee_per_gas,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
             r,
             s,
             v,

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -54,15 +54,25 @@ FROM
             input_data,
             tx_status AS status,
             effective_gas_price,
-            utils.udf_hex_to_int(
-                DATA :maxFeePerGas :: STRING
-            ) :: INT / pow(
+            TO_NUMBER(REPLACE(DATA :maxFeePerGas :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :maxFeePerGas :: STRING, '0x')))) / pow(
                 10,
                 9
             ) AS max_fee_per_gas,
-            utils.udf_hex_to_int(
-                DATA :maxPriorityFeePerGas :: STRING
-            ) :: INT / pow(
+            TO_NUMBER(
+                REPLACE(
+                    DATA :maxPriorityFeePerGas :: STRING,
+                    '0x'
+                ),
+                REPEAT(
+                    'X',
+                    LENGTH(
+                        REPLACE(
+                            DATA :maxPriorityFeePerGas :: STRING,
+                            '0x'
+                        )
+                    )
+                )
+            ) / pow(
                 10,
                 9
             ) AS max_priority_fee_per_gas,

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -26,6 +26,8 @@ SELECT
     input_data,
     status,
     effective_gas_price,
+    max_fee_per_gas,
+    max_priority_fee_per_gas,
     r,
     s,
     v,
@@ -52,6 +54,18 @@ FROM
             input_data,
             tx_status AS status,
             effective_gas_price,
+            utils.udf_hex_to_int(
+                DATA :maxFeePerGas :: STRING
+            ) :: INT / pow(
+                10,
+                9
+            ) AS max_fee_per_gas,
+            utils.udf_hex_to_int(
+                DATA :maxPriorityFeePerGas :: STRING
+            ) :: INT / pow(
+                10,
+                9
+            ) AS max_priority_fee_per_gas,
             r,
             s,
             v,

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -46,6 +46,10 @@ models:
         description: '{{ doc("bsc_tx_origin_sig") }}'
       - name: EFFECTIVE_GAS_PRICE
         description: The effective gas price of the transaction, in wei.
+      - name: MAX_FEE_PER_GAS
+        description: The maximum fee per gas of the transaction, in Gwei.
+      - name: MAX_PRIORITY_FEE_PER_GAS
+        description: The maximum priority fee per gas of the transaction, in Gwei.
       - name: TX_TYPE
         description: The type of the transaction, 2 for EIP-1559 transactions and 0 for legacy transactions.
       - name: r

--- a/models/silver/core/silver__blocks.sql
+++ b/models/silver/core/silver__blocks.sql
@@ -8,6 +8,9 @@
 
 SELECT
     block_number,
+    TRY_TO_NUMBER(utils.udf_hex_to_int(
+        DATA :result :baseFeePerGas :: STRING
+    )) AS base_fee_per_gas,
     utils.udf_hex_to_int(
         DATA :result :difficulty :: STRING
     ) :: INT AS difficulty,
@@ -45,6 +48,7 @@ SELECT
     ) AS tx_count,
     DATA :result :transactionsRoot :: STRING AS transactions_root,
     DATA :result :uncles AS uncles,
+    DATA,
     _inserted_timestamp
 FROM
 

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -2,13 +2,12 @@
 {{ config(
     materialized = 'incremental',
     on_schema_change = 'append_new_columns',
-    unique_key = ['block_number', 'position'],
+    unique_key = "block_number",
     cluster_by = "block_timestamp::date, _inserted_timestamp::date",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     tags = ['core','non_realtime']
 ) }}
 {# incremental_strategy = 'delete+insert',
-unique_key = "block_number",
 #}
 WITH base AS (
 

--- a/models/silver/core/tests/blocks/test_silver__blocks_full.yml
+++ b/models/silver/core/tests/blocks/test_silver__blocks_full.yml
@@ -23,6 +23,12 @@ models:
               column_type_list:
                 - TIMESTAMP_LTZ
                 - TIMESTAMP_NTZ
+      - name: BASE_FEE_PER_GAS
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
       - name: DIFFICULTY
         tests:
           - not_null

--- a/models/silver/core/tests/blocks/test_silver__blocks_full.yml
+++ b/models/silver/core/tests/blocks/test_silver__blocks_full.yml
@@ -25,6 +25,8 @@ models:
                 - TIMESTAMP_NTZ
       - name: BASE_FEE_PER_GAS
         tests:
+          - not_null:
+              where: BLOCK_NUMBER >= 31302048
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER

--- a/models/silver/core/tests/transactions/test_silver__transactions_full.yml
+++ b/models/silver/core/tests/transactions/test_silver__transactions_full.yml
@@ -115,5 +115,13 @@ models:
       - name: ORIGIN_FUNCTION_SIGNATURE
         tests:
           - not_null
+      - name: MAX_FEE_PER_GAS
+        tests:
+          - not_null:
+              where: BLOCK_NUMBER >= 31302048 AND TX_TYPE = 2
+      - name: MAX_PRIORITY_FEE_PER_GAS
+        tests:
+          - not_null:
+              where: BLOCK_NUMBER >= 31302048 AND TX_TYPE = 2
 
 


### PR DESCRIPTION
1. Adds new fee related columns to blocks and txns for recent hard fork / rpc updates
2. Confirmed that tx_fee calc does not require changes
3. Updated docs
4. Pulled DATA column through silver.blocks 
5. Requires FR on silver.blocks and test blocks_full, incremental on txns w/follow up to revert logic