### PR TITLE
AN-3955/delete-insert-logs

### DIFF
--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -49,5 +49,5 @@ jobs:
   
       - name: Execute block_reorg macro
         run: |
-          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}"
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && grep -E "SQL status|/* {" logs/dbt.log
         

--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -1,0 +1,53 @@
+name: dbt_run_operation_reorg
+run-name: dbt_run_operation_reorg
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at minute 25 every 8 hours (see https://crontab.guru)
+    - cron: '25 */8 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+
+      - name: List reorg models
+        id: list_models
+        run: |
+          reorg_model_list=$(dbt list --select tag:reorg --resource-type model | awk -F'.' '{print $NF}' | tr '\n' ',' | sed 's/,$//')
+          echo "::set-output name=model_list::$reorg_model_list"
+  
+      - name: Execute block_reorg macro
+        run: |
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}"
+        

--- a/models/gold/core/core__ez_bnb_transfers.sql
+++ b/models/gold/core/core__ez_bnb_transfers.sql
@@ -3,10 +3,8 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
-    tags = ['core','non_realtime'],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    tags = ['core','non_realtime','reorg'],
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}

--- a/models/gold/core/core__ez_bnb_transfers.sql
+++ b/models/gold/core/core__ez_bnb_transfers.sql
@@ -3,6 +3,9 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     tags = ['core','non_realtime'],
     persist_docs ={ "relation": true,
     "columns": true }

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -5,10 +5,8 @@
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
     full_refresh = false,
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
-    tags = ['decoded_logs']
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    tags = ['decoded_logs','reorg']
 ) }}
 
 WITH base_data AS (

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -5,7 +5,9 @@
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
     full_refresh = false,
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     tags = ['decoded_logs']
 ) }}
 

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH logs AS (

--- a/models/silver/dex/biswap/silver_dex__biswap_pools.sql
+++ b/models/silver/dex/biswap/silver_dex__biswap_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/biswap/silver_dex__biswap_swaps.sql
+++ b/models/silver/dex/biswap/silver_dex__biswap_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/biswap/silver_dex__biswap_swaps.sql
+++ b/models/silver/dex/biswap/silver_dex__biswap_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/biswap/silver_dex__biswap_swaps.sql
+++ b/models/silver/dex/biswap/silver_dex__biswap_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -69,7 +70,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -74,7 +75,7 @@ sell_base_token AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -127,7 +128,7 @@ buy_base_token AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_pools.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -42,7 +43,7 @@ WITH pools AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -97,7 +98,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -33,7 +34,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/hashflow/silver_dex__hashflow_pools.sql
+++ b/models/silver/dex/hashflow/silver_dex__hashflow_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -27,7 +28,7 @@ WITH contract_deployments AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -49,7 +50,7 @@ router_swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -92,7 +93,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -36,7 +37,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -67,7 +68,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -42,7 +43,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -67,7 +68,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -33,7 +34,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -80,7 +81,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/level/silver_dex__levelfi_swaps.sql
+++ b/models/silver/dex/level/silver_dex__levelfi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH swaps_base AS (

--- a/models/silver/dex/level/silver_dex__levelfi_swaps.sql
+++ b/models/silver/dex/level/silver_dex__levelfi_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/level/silver_dex__levelfi_swaps.sql
+++ b/models/silver/dex/level/silver_dex__levelfi_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -77,7 +78,7 @@ WITH swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v1_pools.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v1_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v1_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v1_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v1_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v1_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v1_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v1_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_amm_pools.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_amm_pools.sql
@@ -35,7 +35,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_amm_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_amm_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_amm_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_amm_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_amm_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_amm_swaps.sql
@@ -63,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_mm_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_mm_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH swaps_base AS (

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_mm_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_mm_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_mm_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_mm_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -61,7 +62,7 @@ WITH swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_ss_pools.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_ss_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -47,7 +48,7 @@ WITH pools AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_ss_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_ss_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_ss_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_ss_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_ss_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v2_ss_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -69,7 +70,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v3_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v3_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v3_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v3_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v3_swaps.sql
+++ b/models/silver/dex/pancake_swap/silver_dex__pancakeswap_v3_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-  tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -3,6 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
+  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
   tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = "_id",
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
   tags = ['non_realtime']
 ) }}
@@ -28,6 +29,7 @@ SELECT
     token0,
     token1,
     'biswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -36,7 +38,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -55,6 +57,7 @@ SELECT
     base_token AS token0,
     quote_token AS token1,
     'dodo-v1' AS platform,
+    'v1' AS version,
     _id,
     _inserted_timestamp
 FROM 
@@ -63,7 +66,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -82,6 +85,7 @@ SELECT
     base_token AS token0,
     quote_token AS token1,
     'dodo-v2' AS platform,
+    'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM 
@@ -91,7 +95,7 @@ WHERE token0 IS NOT NULL
 AND
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -110,6 +114,7 @@ SELECT
     token0,
     token1,
     'fraxswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -118,7 +123,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -137,6 +142,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v1' AS platform,
+    'v1-dynamic' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -145,7 +151,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -164,6 +170,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v1' AS platform,
+    'v1-static' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -172,7 +179,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -192,6 +199,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v2' AS platform,
+    'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -200,7 +208,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -219,6 +227,7 @@ SELECT
     token0,
     token1,
     'pancakeswap-v1' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -227,7 +236,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -246,6 +255,7 @@ SELECT
     token0,
     token1,
     'pancakeswap-v2' AS platform,
+    'v2-amm' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -254,7 +264,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -271,6 +281,7 @@ SELECT
     pool_address,
     NULL AS pool_name,
     'pancakeswap-v2' AS platform,
+    'v2-ss' AS version,
     _log_id AS _id,
     _inserted_timestamp,
     tokenA AS token0,
@@ -282,7 +293,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -302,6 +313,7 @@ SELECT
     token0_address AS token0,
     token1_address AS token1,
     'pancakeswap-v3' AS platform,
+    'v3' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -310,7 +322,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -329,6 +341,7 @@ SELECT
     token0,
     token1,
     'sushiswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -337,7 +350,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -356,6 +369,7 @@ SELECT
     token0,
     token1,
     'trader-joe-v1' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -364,7 +378,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -383,6 +397,7 @@ SELECT
     tokenX AS token0,
     tokenY AS token1,
     'trader-joe-v2' AS platform,
+    'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -391,7 +406,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -411,6 +426,7 @@ SELECT
     token0_address AS token0,
     token1_address AS token1,
     'uniswap-v3' AS platform,
+    'v3' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -419,7 +435,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -497,6 +513,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_standard p 
@@ -523,6 +540,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_v3 p 
@@ -550,6 +568,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0', c0.symbol, 'token1', c1.symbol, 'token2', c2.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0', c0.decimals, 'token1', c1.decimals, 'token2', c2.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_other p
@@ -566,6 +585,7 @@ SELECT
     block_timestamp,
     tx_hash,
     platform,
+    version,
     contract_address,
     pool_address,
     pool_name,

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-  tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -3,6 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
+  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
   tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -1,7 +1,7 @@
 {{ config(
   materialized = 'incremental',
   incremental_strategy = 'delete+insert',
-  unique_key = "block_number",
+  unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
   tags = ['non_realtime']
 ) }}
@@ -30,15 +30,6 @@ prices AS (
       FROM
         contracts
     )
-
-{% if is_incremental() %}
-AND HOUR >= (
-  SELECT
-    MAX(_inserted_timestamp) :: DATE - 2
-  FROM
-    {{ this }}
-)
-{% endif %}
 ),
 univ3_swaps AS (
   SELECT
@@ -93,6 +84,7 @@ univ3_swaps AS (
     recipient AS tx_to,
     event_index,
     'uniswap-v3' AS platform,
+    'v3' AS version,
     CASE
       WHEN amount0_unadj > 0 THEN token0_address
       ELSE token1_address
@@ -135,7 +127,7 @@ univ3_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -169,6 +161,7 @@ woofi_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     CONCAT(
@@ -196,7 +189,7 @@ woofi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -230,6 +223,7 @@ kyberswap_v1_dynamic AS (
     tx_to,
     event_index,
     platform,
+    'v1-dynamic' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -247,7 +241,7 @@ kyberswap_v1_dynamic AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -281,6 +275,7 @@ kyberswap_v1_static AS (
     tx_to,
     event_index,
     platform,
+    'v1-static' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -298,7 +293,7 @@ kyberswap_v1_static AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -332,6 +327,7 @@ kyberswap_v2_elastic AS (
     tx_to,
     event_index,
     platform,
+    'v2' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -349,7 +345,7 @@ kyberswap_v2_elastic AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -383,6 +379,7 @@ fraxswap_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -400,7 +397,7 @@ fraxswap_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -434,6 +431,7 @@ sushi_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -451,7 +449,7 @@ sushi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -485,6 +483,7 @@ dodo_v1_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -502,7 +501,7 @@ dodo_v1_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -536,6 +535,7 @@ dodo_v2_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v2' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -553,7 +553,7 @@ dodo_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -587,6 +587,7 @@ hashflow_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     CONCAT(
@@ -614,7 +615,7 @@ hashflow_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -648,6 +649,7 @@ trader_joe_v1_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -665,7 +667,7 @@ trader_joe_v1_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -699,6 +701,7 @@ trader_joe_v2_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v2' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -716,7 +719,7 @@ trader_joe_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -750,6 +753,7 @@ trader_joe_v2_1_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v2.1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -767,7 +771,7 @@ trader_joe_v2_1_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -801,6 +805,7 @@ biswap_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -818,7 +823,7 @@ biswap_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -852,6 +857,7 @@ levelfi_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     CONCAT(
@@ -879,7 +885,7 @@ levelfi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -913,6 +919,7 @@ pancakeswap_v1_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v1' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -930,7 +937,7 @@ pancakeswap_v1_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -964,6 +971,7 @@ pancakeswap_v2_amm_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v2-amm' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -981,7 +989,7 @@ pancakeswap_v2_amm_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -1015,6 +1023,7 @@ pancakeswap_v2_mm_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v2-mm' AS version,
     token_in,
     token_out,
     CONCAT(
@@ -1042,7 +1051,7 @@ pancakeswap_v2_mm_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -1076,6 +1085,7 @@ pancakeswap_v2_ss_swaps AS (
     tx_to,
     event_index,
     platform,
+    'v2-ss' AS version,
     token_in,
     token_out,
     NULL AS pool_name,
@@ -1093,7 +1103,7 @@ pancakeswap_v2_ss_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -1154,6 +1164,7 @@ pancakeswap_v3_swaps AS (
     recipient_address AS tx_to,
     event_index,
     'pancakeswap-v3' AS platform,
+    'v3' AS version,
     CASE
       WHEN amount0_unadj > 0 THEN token0_address
       ELSE token1_address
@@ -1196,7 +1207,7 @@ pancakeswap_v3_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '36 hours'
     FROM
       {{ this }}
   )
@@ -1222,6 +1233,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1251,6 +1263,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1280,6 +1293,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1309,6 +1323,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1338,6 +1353,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1367,6 +1383,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1396,6 +1413,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1425,6 +1443,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1454,6 +1473,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1483,6 +1503,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1512,6 +1533,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1541,6 +1563,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1570,6 +1593,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1599,6 +1623,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1628,6 +1653,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1657,6 +1683,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1686,6 +1713,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1715,6 +1743,7 @@ all_dex_standard AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1748,6 +1777,7 @@ all_dex_custom AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1777,6 +1807,7 @@ all_dex_custom AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1819,6 +1850,7 @@ FINAL AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1866,6 +1898,7 @@ FINAL AS (
     tx_to,
     event_index,
     platform,
+    version,
     token_in,
     token_out,
     symbol_in,
@@ -1908,6 +1941,7 @@ SELECT
   tx_to,
   event_index,
   f.platform,
+  f.version,
   token_in,
   token_out,
   symbol_in,

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -62,7 +63,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -84,7 +85,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "lb_pair",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -37,7 +38,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -83,7 +84,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base_swaps AS (

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH router_swaps_base AS (

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -67,7 +68,7 @@ WITH router_swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -139,7 +140,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform_name','platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH nft_base_models AS (

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform_name','platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['block_number','platform_name','platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -40,9 +41,7 @@ WITH nft_base_models AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(
-                _inserted_timestamp
-            ) :: DATE - 1
+            MAX(_inserted_timestamp) - INTERVAL '36 hours'
         FROM
             {{ this }}
     )
@@ -81,9 +80,7 @@ FROM
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(
-                _inserted_timestamp
-            ) :: DATE - 1
+            MAX(_inserted_timestamp) - INTERVAL '36 hours'
         FROM
             {{ this }}
     )
@@ -122,9 +119,7 @@ FROM
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(
-                _inserted_timestamp
-            ) :: DATE - 1
+            MAX(_inserted_timestamp) - INTERVAL '36 hours'
         FROM
             {{ this }}
     )
@@ -152,15 +147,6 @@ prices_raw AS (
             FROM
                 nft_base_models
         )
-
-{% if is_incremental() %}
-AND HOUR >= (
-    SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
-    FROM
-        {{ this }}
-)
-{% endif %}
 ),
 all_prices AS (
     SELECT

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -3,10 +3,8 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
-    tags = ['non_realtime']
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base AS (

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -3,7 +3,9 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
     tags = ['non_realtime']

--- a/models/silver/nft/silver__seaport_1_1_sales.sql
+++ b/models/silver/nft/silver__seaport_1_1_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH seaport_fees_wallet AS (

--- a/models/silver/nft/silver__seaport_1_1_sales.sql
+++ b/models/silver/nft/silver__seaport_1_1_sales.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__seaport_1_1_sales.sql
+++ b/models/silver/nft/silver__seaport_1_1_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -31,9 +32,7 @@ seaport_tx_table AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -74,9 +73,7 @@ decoded AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1051,9 +1048,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1094,9 +1089,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_4_sales.sql
+++ b/models/silver/nft/silver__seaport_1_4_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH seaport_fees_wallet AS (

--- a/models/silver/nft/silver__seaport_1_4_sales.sql
+++ b/models/silver/nft/silver__seaport_1_4_sales.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__seaport_1_4_sales.sql
+++ b/models/silver/nft/silver__seaport_1_4_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -30,9 +31,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -90,9 +89,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1656,9 +1653,7 @@ mao_orderhash AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1699,9 +1694,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH seaport_fees_wallet AS (

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -30,9 +31,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -90,9 +89,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1656,10 +1653,8 @@ mao_orderhash AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
-    FROM
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
+    FROM 
         {{ this }}
 )
 {% endif %}
@@ -1699,9 +1694,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -28,9 +28,7 @@ WHERE
 {% if is_incremental() %}
 AND p._inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.6.0
+    revision: v1.6.1
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.5.0
+    revision: v1.6.0
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
1. Changes incremental strategy to delete+insert on `block_number` in majority of logs based downstream models
2. Minimizes incremental lookback to rolling 12-24 hrs vs 1-3 days, with exceptions
3. FR required on complete_dex_swaps, complete_dex_liquidity_pools to add `version` columns
4. Adds new workflow for block reorg macro, scheduled to run 3x daily - based on `reorg` tag