### PR TITLE
stash

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -26,6 +26,7 @@ clean-targets: # directories to be removed by `dbt clean`
 
 models:
   +copy_grants: true  
+  +on_schema_change: "append_new_columns"
 
 tests:
   +store_failures: true # all tests

--- a/models/doc_descriptions/general/deprecation.md
+++ b/models/doc_descriptions/general/deprecation.md
@@ -1,13 +1,11 @@
-{% docs deprecation %}
+{% docs internal_column %}    
 
-Deprecating soon: This is a notice that we're only removing the below columns. Please migrate queries using these columns to `fact_decoded_event_logs`, `ez_decoded_event_logs` or use manual parsing of topics and data. The following columns will be deprecated on 6/6/23:
+Deprecated. This column is no longer used. Please remove from your query by Jan. 10 2024.'
 
-`Fact_event_logs` Columns:
-- `event_name`
-- `event_inputs`
-- `contract_name`
-
-`Fact_transactions` Columns:
-- `tx_json`
 {% enddocs %}
 
+{% docs amount_deprecation %}   
+
+This column is being deprecated for standardization purposes on Jan. 10 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `avax_amount`.
+
+{% enddocs %}

--- a/models/doc_descriptions/general/deprecation.md
+++ b/models/doc_descriptions/general/deprecation.md
@@ -1,11 +1,11 @@
 {% docs internal_column %}    
 
-Deprecated. This column is no longer used. Please remove from your query by Jan. 10 2024.'
+Deprecated. This column is no longer used. Please remove from your query by Jan. 31 2024.'
 
 {% enddocs %}
 
 {% docs amount_deprecation %}   
 
-This column is being deprecated for standardization purposes on Jan. 10 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `avax_amount`.
+This column is being deprecated for standardization purposes on Jan. 31 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `bnb_amount`.
 
 {% enddocs %}

--- a/models/doc_descriptions/general/export_columns.md
+++ b/models/doc_descriptions/general/export_columns.md
@@ -1,0 +1,19 @@
+{% docs pk %}
+
+The unique identifier for each row in the table.
+
+{% enddocs %}
+
+{% docs inserted_timestamp %}
+
+The utc timestamp at which the row was inserted into the table.
+
+{% enddocs %}
+
+{% docs modified_timestamp %}
+
+The utc timestamp at which the row was last modified.
+
+{% enddocs %}
+
+

--- a/models/doc_descriptions/nft/nft_intra_event_index.md
+++ b/models/doc_descriptions/nft/nft_intra_event_index.md
@@ -1,0 +1,5 @@
+{% docs nft_intra_event_index %}
+
+The order of events within a single event index. This is primarily used for ERC1155 NFT batch transfer events. 
+
+{% enddocs %}

--- a/models/doc_descriptions/traces/bsc_traces_index.md
+++ b/models/doc_descriptions/traces/bsc_traces_index.md
@@ -1,0 +1,5 @@
+{% docs bsc_trace_index %}
+
+The index of the trace within the transaction.
+
+{% enddocs %}

--- a/models/gold/core/core__dim_contracts.sql
+++ b/models/gold/core/core__dim_contracts.sql
@@ -12,7 +12,15 @@ SELECT
     c0.block_number AS created_block_number,
     c0.block_timestamp AS created_block_timestamp,
     c0.tx_hash AS created_tx_hash,
-    c0.creator_address AS creator_address
+    c0.creator_address AS creator_address,
+    COALESCE (
+        c0.created_contracts_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['c0.created_contract_address']
+        ) }}
+    ) AS dim_contracts_id,
+    GREATEST(COALESCE(c0.inserted_timestamp, '2000-01-01'), COALESCE(c1.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
+    GREATEST(COALESCE(c0.modified_timestamp, '2000-01-01'), COALESCE(c1.modified_timestamp, '2000-01-01')) AS modified_timestamp
 FROM
     {{ ref('silver__created_contracts') }}
     c0

--- a/models/gold/core/core__dim_contracts.yml
+++ b/models/gold/core/core__dim_contracts.yml
@@ -20,3 +20,9 @@ models:
         description: 'The transaction hash when the contract was created'
       - name: CREATOR_ADDRESS
         description: 'The address of the creator of the contract'
+      - name: DIM_CONTRACTS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/core/core__dim_labels.sql
+++ b/models/gold/core/core__dim_labels.sql
@@ -11,6 +11,20 @@ SELECT
     address_name,
     label_type,
     label_subtype,
-    project_name
+    project_name,
+    COALESCE (
+        labels_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['address']
+        ) }}
+    ) AS dim_labels_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__labels') }}

--- a/models/gold/core/core__dim_labels.yml
+++ b/models/gold/core/core__dim_labels.yml
@@ -52,4 +52,9 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
-
+      - name: DIM_LABELS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__ez_bnb_transfers.sql
+++ b/models/gold/core/core__ez_bnb_transfers.sql
@@ -1,106 +1,26 @@
 {{ config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = 'block_number',
-    cluster_by = ['block_timestamp::DATE'],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-    tags = ['core','non_realtime','reorg'],
+    materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}
 
-WITH bnb_base AS (
-
-    SELECT
-        tx_hash,
-        block_number,
-        block_timestamp,
-        identifier,
-        from_address,
-        to_address,
-        bnb_value,
-        _call_id,
-        _inserted_timestamp,
-        bnb_value_precise_raw,
-        bnb_value_precise,
-        tx_position,
-        trace_index
-    FROM
-        {{ ref('silver__traces') }}
-    WHERE
-        bnb_value > 0
-        AND tx_status = 'SUCCESS'
-        AND trace_status = 'SUCCESS'
-        AND TYPE NOT IN (
-            'DELEGATECALL',
-            'STATICCALL'
-        )
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '72 hours'
-    FROM
-        {{ this }}
-)
-{% endif %}
-),
-tx_table AS (
-    SELECT
-        block_number,
-        tx_hash,
-        from_address AS origin_from_address,
-        to_address AS origin_to_address,
-        origin_function_signature
-    FROM
-        {{ ref('silver__transactions') }}
-    WHERE
-        tx_hash IN (
-            SELECT
-                DISTINCT tx_hash
-            FROM
-                bnb_base
-        )
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '72 hours'
-    FROM
-        {{ this }}
-)
-{% endif %}
-)
 SELECT
-    tx_hash AS tx_hash,
-    block_number AS block_number,
-    block_timestamp AS block_timestamp,
-    identifier AS identifier,
+    tx_hash,
+    block_number,
+    block_timestamp,
+    identifier,
     origin_from_address,
     origin_to_address,
     origin_function_signature,
     from_address AS bnb_from_address,
     to_address AS bnb_to_address,
-    bnb_value AS amount,
-    bnb_value_precise_raw AS amount_precise_raw,
-    bnb_value_precise AS amount_precise,
-    ROUND(
-        bnb_value * price,
-        2
-    ) AS amount_usd,
+    amount,
+    amount_precise_raw,
+    amount_precise,
+    amount_usd,
     _call_id,
     _inserted_timestamp,
     tx_position,
     trace_index
 FROM
-    bnb_base A
-    LEFT JOIN {{ ref('silver__hourly_prices_all_providers') }}
-    ON DATE_TRUNC(
-        'hour',
-        A.block_timestamp
-    ) = HOUR
-    AND token_address = LOWER('0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c')
-    JOIN tx_table USING (
-        tx_hash,
-        block_number
-    )
+    {{ ref('silver__native_transfers') }}

--- a/models/gold/core/core__ez_bnb_transfers.yml
+++ b/models/gold/core/core__ez_bnb_transfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: core__ez_bnb_transfers
-    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 10 2024.'
+    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 31 2024.'
       
     columns:
       - name: BLOCK_NUMBER

--- a/models/gold/core/core__ez_bnb_transfers.yml
+++ b/models/gold/core/core__ez_bnb_transfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: core__ez_bnb_transfers
-    description: '{{ doc("bsc_ez_eth_transfers_table_doc") }}'
+    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 10 2024.'
       
     columns:
       - name: BLOCK_NUMBER

--- a/models/gold/core/core__ez_decoded_event_logs.sql
+++ b/models/gold/core/core__ez_decoded_event_logs.sql
@@ -20,8 +20,16 @@ SELECT
     topics,
     DATA,
     event_removed,
-    tx_status
+    tx_status,    
+    COALESCE (
+        decoded_logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS ez_decoded_event_logs_id,
+    GREATEST(COALESCE(l.inserted_timestamp, '2000-01-01'), COALESCE(C.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
+    GREATEST(COALESCE(l.modified_timestamp, '2000-01-01'), COALESCE(C.modified_timestamp, '2000-01-01')) AS modified_timestamp
 FROM
-    {{ ref('silver__decoded_logs') }} 
-    LEFT JOIN {{ ref('silver__contracts') }} 
+    {{ ref('silver__decoded_logs') }} l
+    LEFT JOIN {{ ref('silver__contracts') }} c
     using (contract_address)

--- a/models/gold/core/core__ez_decoded_event_logs.yml
+++ b/models/gold/core/core__ez_decoded_event_logs.yml
@@ -57,3 +57,9 @@ models:
         description: '{{ doc("bsc_event_removed") }}' 
       - name: TX_STATUS
         description: '{{ doc("bsc_tx_status") }}' 
+      - name: EZ_DECODED_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__ez_native_transfers.sql
+++ b/models/gold/core/core__ez_native_transfers.sql
@@ -5,34 +5,27 @@
 ) }}
 
 SELECT
+    tx_hash,
     block_number,
     block_timestamp,
-    tx_hash,
-    event_index,
-    origin_function_signature,
+    tx_position,
+    trace_index,
+    identifier,
     origin_from_address,
     origin_to_address,
-    contract_address,
+    origin_function_signature,
     from_address,
     to_address,
-    raw_amount_precise,
-    raw_amount,
-    amount_precise,
     amount,
+    amount_precise_raw,
+    amount_precise,
     amount_usd,
-    decimals,
-    symbol,
-    token_price,
-    has_decimal,
-    has_price,
-    _log_id,
-    _inserted_timestamp,
     COALESCE (
-        transfers_id,
+        native_transfers_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['tx_hash', 'event_index']
+            ['tx_hash', 'trace_index']
         ) }}
-    ) AS ez_token_transfers_id,
+    ) AS ez_native_transfers_id,
     COALESCE(
         inserted_timestamp,
         '2000-01-01'
@@ -42,4 +35,4 @@ SELECT
         '2000-01-01'
     ) AS modified_timestamp
 FROM
-    {{ ref('silver__transfers') }}
+    {{ ref('silver__native_transfers') }}

--- a/models/gold/core/core__ez_native_transfers.yml
+++ b/models/gold/core/core__ez_native_transfers.yml
@@ -1,0 +1,42 @@
+version: 2
+models:
+  - name: core__ez_native_transfers
+    description: '{{ doc("bsc_ez_eth_transfers_table_doc") }}'
+
+    columns:
+      - name: TX_HASH
+        description: '{{ doc("bsc_transfer_tx_hash") }}'
+      - name: BLOCK_NUMBER
+        description: '{{ doc("bsc_block_number") }}'
+      - name: BLOCK_TIMESTAMP
+        description: '{{ doc("bsc_block_timestamp") }}'
+      - name: TX_POSITION
+        description: '{{ doc("bsc_tx_position") }}'
+      - name: TRACE_INDEX
+        description: '{{ doc("bsc_trace_index") }}'
+      - name: IDENTIFIER
+        description: '{{ doc("bsc_traces_identifier") }}'
+      - name: ORIGIN_FROM_ADDRESS
+        description: '{{ doc("bsc_origin_from") }}'
+      - name: ORIGIN_TO_ADDRESS
+        description: '{{ doc("bsc_origin_to") }}'
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        description: '{{ doc("bsc_origin_sig") }}'
+      - name: FROM_ADDRESS
+        description: '{{ doc("bsc_transfer_from_address") }}'
+      - name: TO_ADDRESS
+        description: '{{ doc("bsc_transfer_to_address") }}'
+      - name: AMOUNT
+        description: '{{ doc("bsc_eth_amount") }}'
+      - name: AMOUNT_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: AMOUNT_PRECISE
+        description: '{{ doc("precise_amount_adjusted") }}'
+      - name: AMOUNT_USD
+        description: '{{ doc("bsc_eth_amount_usd") }}' 
+      - name: EZ_NATIVE_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__ez_token_transfers.yml
+++ b/models/gold/core/core__ez_token_transfers.yml
@@ -47,4 +47,12 @@ models:
       - name: HAS_PRICE
         description: '{{ doc("bsc_transfer_has_price") }}'
       - name: _LOG_ID
-        description: '{{ doc("bsc_log_id_transfers") }}'
+        description: '{{ doc("internal_column") }}'
+      - name: _INSERTED_TIMESTAMP
+        description: '{{ doc("internal_column") }}'
+      - name: EZ_TOKEN_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_blocks.sql
+++ b/models/gold/core/core__fact_blocks.sql
@@ -60,6 +60,20 @@ SELECT
         transactions_root,
         'uncles',
         uncles
-    ) AS block_header_json
+    ) AS block_header_json,
+    COALESCE (
+        blocks_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['block_number']
+        ) }}
+    ) AS fact_blocks_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__blocks') }}

--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -40,3 +40,9 @@ models:
         description: '{{ doc("bsc_uncle_blocks") }}' 
       - name: BLOCK_HEADER_JSON
         description: '{{ doc("bsc_block_header_json") }}'
+      - name: FACT_BLOCKS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/core/core__fact_decoded_event_logs.sql
+++ b/models/gold/core/core__fact_decoded_event_logs.sql
@@ -12,6 +12,20 @@ SELECT
     contract_address,
     event_name,
     decoded_flat AS decoded_log,
-    decoded_data AS full_decoded_log
+    decoded_data AS full_decoded_log,
+    COALESCE (
+        decoded_logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_decoded_event_logs_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__decoded_logs') }}

--- a/models/gold/core/core__fact_decoded_event_logs.yml
+++ b/models/gold/core/core__fact_decoded_event_logs.yml
@@ -42,3 +42,9 @@ models:
         description: 'The flattened decoded log, where the keys are the names of the event parameters, and the values are the values of the event parameters.'
       - name: FULL_DECODED_LOG
         description: 'The full decoded log, including the event name, the event parameters, and the data type of the event parameters.'  
+      - name: FACT_DECODED_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_event_logs.sql
+++ b/models/gold/core/core__fact_event_logs.sql
@@ -17,6 +17,20 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    _log_id
+    _log_id,
+    COALESCE (
+        logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_event_logs_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__logs') }}

--- a/models/gold/core/core__fact_event_logs.yml
+++ b/models/gold/core/core__fact_event_logs.yml
@@ -21,7 +21,7 @@ models:
       - name: EVENT_REMOVED
         description: '{{ doc("bsc_event_removed") }}'  
       - name: _LOG_ID
-        description: '{{ doc("bsc_log_id_events") }}'  
+        description: '{{ doc("internal_column") }}'  
       - name: TX_STATUS
         description: '{{ doc("bsc_tx_status") }}' 
       - name: ORIGIN_FUNCTION_SIGNATURE
@@ -30,3 +30,9 @@ models:
         description: '{{ doc("bsc_origin_from") }}'
       - name: ORIGIN_TO_ADDRESS
         description: '{{ doc("bsc_origin_to") }}'
+      - name: FACT_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_token_transfers.sql
+++ b/models/gold/core/core__fact_token_transfers.sql
@@ -17,6 +17,20 @@ SELECT
     to_address,
     raw_amount,
     raw_amount_precise,
-    _log_id
+    _log_id,
+    COALESCE (
+        transfers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_token_transfers_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__transfers') }}

--- a/models/gold/core/core__fact_token_transfers.yml
+++ b/models/gold/core/core__fact_token_transfers.yml
@@ -29,4 +29,10 @@ models:
       - name: RAW_AMOUNT_PRECISE
         description: '{{ doc("bsc_transfer_raw_amount_precise") }}'
       - name: _LOG_ID
-        description: '{{ doc("bsc_log_id_transfers") }}'
+        description: '{{ doc("internal_column") }}'
+      - name: FACT_TOKEN_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_traces.sql
+++ b/models/gold/core/core__fact_traces.sql
@@ -10,9 +10,9 @@ SELECT
     block_timestamp,
     from_address,
     to_address,
-    bnb_value,
-    bnb_value_precise_raw,
-    bnb_value_precise,
+    bnb_value AS VALUE,
+    bnb_value_precise_raw AS value_precise_raw,
+    bnb_value_precise AS value_precise,
     gas,
     gas_used,
     input,
@@ -24,6 +24,23 @@ SELECT
     sub_traces,
     trace_status,
     error_reason,
-    trace_index
+    trace_index,
+    COALESCE (
+        traces_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'trace_index']
+        ) }}
+    ) AS fact_traces_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp,
+    bnb_value,
+    bnb_value_precise_raw,
+    bnb_value_precise
 FROM
     {{ ref('silver__traces') }}

--- a/models/gold/core/core__fact_traces.yml
+++ b/models/gold/core/core__fact_traces.yml
@@ -44,6 +44,12 @@ models:
         description: The reason for the trace failure, if any.
       - name: TRACE_INDEX
         description: The index of the trace within the transaction. 
+      - name: FACT_TRACES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
 
 
         

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -14,67 +14,34 @@ SELECT
     origin_function_signature,
     from_address,
     to_address,
-    bnb_value,
-    bnb_value_precise_raw,
-    bnb_value_precise,
+    VALUE,
+    value_precise_raw,
+    value_precise,
     tx_fee,
     tx_fee_precise,
     gas_price,
-    gas_limit,
+    gas AS gas_limit,
     gas_used,
     cumulative_gas_used,
     input_data,
-    status,
+    tx_status AS status,
     effective_gas_price,
     max_fee_per_gas,
     max_priority_fee_per_gas,
     r,
     s,
     v,
-    tx_type
+    tx_type,
+    COALESCE (
+        transactions_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash']
+        ) }}
+    ) AS fact_transactions_id,
+    GREATEST(COALESCE(A.inserted_timestamp, '2000-01-01'), COALESCE(b.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
+    GREATEST(COALESCE(A.modified_timestamp, '2000-01-01'), COALESCE(b.modified_timestamp, '2000-01-01')) AS modified_timestamp,
+    VALUE AS bnb_value,
+    value_precise_raw AS bnb_value_precise_raw,
+    value_precise AS bnb_value_precise
 FROM
-    (
-        SELECT
-            block_number,
-            block_timestamp,
-            block_hash,
-            tx_hash,
-            nonce,
-            POSITION,
-            origin_function_signature,
-            from_address,
-            to_address,
-            VALUE AS bnb_value,
-            tx_fee,
-            tx_fee_precise,
-            gas_price,
-            gas AS gas_limit,
-            gas_used,
-            cumulative_gas_used,
-            input_data,
-            tx_status AS status,
-            effective_gas_price,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            r,
-            s,
-            v,
-            tx_type,
-            to_varchar(
-                TO_NUMBER(REPLACE(DATA :value :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :value :: STRING, '0x'))))
-            ) AS bnb_value_precise_raw,
-            IFF(LENGTH(bnb_value_precise_raw) > 18, LEFT(bnb_value_precise_raw, LENGTH(bnb_value_precise_raw) - 18) || '.' || RIGHT(bnb_value_precise_raw, 18), '0.' || LPAD(bnb_value_precise_raw, 18, '0')) AS rough_conversion,
-            IFF(
-                POSITION(
-                    '.000000000000000000' IN rough_conversion
-                ) > 0,
-                LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
-                REGEXP_REPLACE(
-                    rough_conversion,
-                    '0*$',
-                    ''
-                )
-            ) AS bnb_value_precise
-        FROM
-            {{ ref('silver__transactions') }}
-    )
+    {{ ref('silver__transactions') }}

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -38,8 +38,14 @@ SELECT
             ['tx_hash']
         ) }}
     ) AS fact_transactions_id,
-    GREATEST(COALESCE(A.inserted_timestamp, '2000-01-01'), COALESCE(b.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
-    GREATEST(COALESCE(A.modified_timestamp, '2000-01-01'), COALESCE(b.modified_timestamp, '2000-01-01')) AS modified_timestamp,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp,
     VALUE AS bnb_value,
     value_precise_raw AS bnb_value_precise_raw,
     value_precise AS bnb_value_precise

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -21,10 +21,16 @@ models:
       - name: TO_ADDRESS
         description: '{{ doc("bsc_to_address") }}' 
       - name: BNB_VALUE
-        description: '{{ doc("bsc_value") }}' 
+        description: '{{ doc("amount_deprecation") }}'
       - name: BNB_VALUE_PRECISE_RAW
-        description: '{{ doc("precise_amount_unadjusted") }}'
+        description: '{{ doc("amount_deprecation") }}'
       - name: BNB_VALUE_PRECISE
+        description: '{{ doc("amount_deprecation") }}'
+      - name: VALUE
+        description: '{{ doc("bsc_value") }}' 
+      - name: VALUE_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: VALUE_PRECISE
         description: '{{ doc("precise_amount_adjusted") }}'
       - name: TX_FEE
         description: '{{ doc("bsc_tx_fee") }}' 
@@ -58,3 +64,9 @@ models:
         description: The s value of the transaction signature.
       - name: v
         description: The v value of the transaction signature.
+      - name: FACT_TRANSACTIONS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.sql
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.sql
@@ -22,6 +22,20 @@ SELECT
     pool_name,
     tokens,
     symbols,
-    decimals
+    decimals,
+    COALESCE (
+        complete_dex_liquidity_pools_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['block_number','platform','version']
+        ) }}
+    ) AS dim_dex_liquidity_pools_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver_dex__complete_dex_liquidity_pools') }}

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.yml
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.yml
@@ -24,3 +24,9 @@ models:
         description: '{{ doc("eth_dex_lp_symbols") }}'
       - name: DECIMALS
         description: '{{ doc("eth_dex_lp_decimals") }}'
+      - name: DIM_DEX_LIQUIDITY_POOLS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/defi/defi__ez_dex_swaps.sql
+++ b/models/gold/defi/defi__ez_dex_swaps.sql
@@ -36,5 +36,19 @@ SELECT
   token_out,
   symbol_in,
   symbol_out,
-  _log_id
+  _log_id,
+    COALESCE (
+        complete_dex_swaps_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash','event_index']
+        ) }}
+    ) AS ez_dex_swaps_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM {{ ref('silver_dex__complete_dex_swaps') }}

--- a/models/gold/defi/defi__ez_dex_swaps.yml
+++ b/models/gold/defi/defi__ez_dex_swaps.yml
@@ -39,7 +39,7 @@ models:
       - name: EVENT_INDEX
         description: '{{ doc("bsc_event_index") }}'
       - name: _LOG_ID
-        description: '{{ doc("bsc_log_id_events") }}'
+        description: '{{ doc("internal_column") }}'
       - name: ORIGIN_FUNCTION_SIGNATURE
         description: '{{ doc("bsc_tx_origin_sig") }}'
       - name: ORIGIN_FROM_ADDRESS
@@ -50,5 +50,10 @@ models:
         description: '{{ doc("eth_dex_swaps_amount_in_unadj") }}'
       - name: AMOUNT_OUT_UNADJ
         description: '{{ doc("eth_dex_swaps_amount_out_unadj") }}'
-
+      - name: EZ_DEX_SWAPS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
 

--- a/models/gold/nft/nft__ez_nft_sales.sql
+++ b/models/gold/nft/nft__ez_nft_sales.sql
@@ -9,6 +9,7 @@ SELECT
     block_number,
     block_timestamp,
     tx_hash,
+    event_index,
     event_type,
     platform_address,
     platform_name,
@@ -31,6 +32,20 @@ SELECT
     creator_fee_usd,
     origin_from_address,
     origin_to_address,
-    origin_function_signature
+    origin_function_signature,
+    COALESCE (
+        complete_nft_sales_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index', 'nft_address','tokenId','platform_exchange_version']
+        ) }}
+    ) AS ez_nft_sales_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__complete_nft_sales') }}

--- a/models/gold/nft/nft__ez_nft_sales.yml
+++ b/models/gold/nft/nft__ez_nft_sales.yml
@@ -10,6 +10,8 @@ models:
         description: '{{ doc("nft_blocktime") }}'
       - name: TX_HASH
         description: '{{ doc("nft_tx_hash") }}' 
+      - name: EVENT_INDEX
+        description: '{{ doc("nft_event_index") }}' 
       - name: EVENT_TYPE
         description: '{{ doc("nft_event_type") }}' 
       - name: PLATFORM_ADDRESS
@@ -54,3 +56,9 @@ models:
         description: '{{ doc("nft_origin_to") }}'
       - name: ORIGIN_FUNCTION_SIGNATURE
         description: '{{ doc("nft_origin_sig") }}'
+      - name: EZ_NFT_SALES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/nft/nft__ez_nft_transfers.sql
+++ b/models/gold/nft/nft__ez_nft_transfers.sql
@@ -10,12 +10,27 @@ SELECT
     block_number,
     tx_hash,
     event_index,
+    intra_event_index,
     event_type,
     contract_address AS nft_address,
     project_name,
     from_address AS nft_from_address,
     to_address AS nft_to_address,
     tokenId,
-    erc1155_value
+    erc1155_value,
+    COALESCE (
+        nft_transfers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash','event_index','intra_event_index']
+        ) }}
+    ) AS ez_nft_transfers_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__nft_transfers') }}

--- a/models/gold/nft/nft__ez_nft_transfers.yml
+++ b/models/gold/nft/nft__ez_nft_transfers.yml
@@ -12,6 +12,8 @@ models:
         description: '{{ doc("nft_tx_hash") }}'
       - name: EVENT_INDEX
         description: '{{ doc("nft_event_index") }}'
+      - name: INTRA_EVENT_INDEX
+        description: '{{ doc("nft_intra_event_index") }}'
       - name: EVENT_TYPE
         description: '{{ doc("nft_event_type") }}'
       - name: NFT_ADDRESS
@@ -26,3 +28,9 @@ models:
         description: '{{ doc("nft_tokenid") }}'
       - name: ERC1155_VALUE
         description: '{{ doc("nft_erc1155_value") }}'
+      - name: EZ_NFT_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/prices/price__dim_asset_metadata.sql
+++ b/models/gold/prices/price__dim_asset_metadata.sql
@@ -10,6 +10,20 @@ SELECT
     symbol,
     NAME,
     decimals,
-    provider
+    provider,
+    COALESCE (
+        asset_metadata_all_providers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address','symbol','id','provider']
+        ) }}
+    ) AS dim_asset_metadata_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__asset_metadata_all_providers') }}

--- a/models/gold/prices/price__dim_asset_metadata.yml
+++ b/models/gold/prices/price__dim_asset_metadata.yml
@@ -23,3 +23,9 @@ models:
         description: The specific address representing the asset in a specific platform.
       - name: DECIMALS
         description: The number of decimal places the token needs adjusted where token values exist.
+      - name: DIM_ASSET_METADATA_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/prices/price__ez_asset_metadata.sql
+++ b/models/gold/prices/price__ez_asset_metadata.sql
@@ -9,6 +9,20 @@ SELECT
     id,
     symbol,
     NAME,
-    decimals
+    decimals,
+    COALESCE (
+        asset_metadata_priority_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address']
+        ) }}
+    ) AS ez_asset_metadata_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__asset_metadata_priority') }}

--- a/models/gold/prices/price__ez_asset_metadata.yml
+++ b/models/gold/prices/price__ez_asset_metadata.yml
@@ -18,3 +18,9 @@ models:
         description: The specific address representing the asset in a specific platform.
       - name: DECIMALS
         description: The number of decimal places the token needs adjusted where token values exist.
+      - name: EZ_ASSET_METADATA_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/prices/price__ez_hourly_token_prices.sql
+++ b/models/gold/prices/price__ez_hourly_token_prices.sql
@@ -10,6 +10,20 @@ SELECT
     symbol,
     decimals,
     price,
-    is_imputed
+    is_imputed,
+    COALESCE (
+        hourly_prices_priority_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address', 'hour']
+        ) }}
+    ) AS ez_hourly_token_prices_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__hourly_prices_priority') }}

--- a/models/gold/prices/price__ez_hourly_token_prices.yml
+++ b/models/gold/prices/price__ez_hourly_token_prices.yml
@@ -21,3 +21,9 @@ models:
         description: Closing price of the recorded hour in USD
       - name: IS_IMPUTED
         description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+      - name: EZ_HOURLY_TOKEN_PRICES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/prices/price__fact_hourly_token_prices.sql
+++ b/models/gold/prices/price__fact_hourly_token_prices.sql
@@ -9,6 +9,20 @@ SELECT
     token_address,
     price,
     is_imputed,
-    provider
+    provider,
+    COALESCE (
+        hourly_prices_all_providers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address', 'hour', 'provider']
+        ) }}
+    ) AS fact_hourly_token_prices_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__hourly_prices_all_providers') }}

--- a/models/gold/prices/price__fact_hourly_token_prices.yml
+++ b/models/gold/prices/price__fact_hourly_token_prices.yml
@@ -14,3 +14,9 @@ models:
         description: Closing price of the recorded hour in USD
       - name: IS_IMPUTED
         description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+      - name: FACT_HOURLY_TOKEN_PRICES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/silver/core/silver__contracts.sql
+++ b/models/silver/core/silver__contracts.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'contract_address',
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -35,66 +36,72 @@ token_names AS (
         block_number,
         function_signature,
         read_output,
-        utils.udf_hex_to_string(SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_name
+        utils.udf_hex_to_string(SUBSTR(read_output,(64 * 2 + 3), len(read_output))) AS token_name
     FROM
         base_metadata
     WHERE
         function_signature = '0x06fdde03'
-        AND token_name IS NOT NULL
-),
-token_symbols AS (
-    SELECT
-        contract_address,
-        block_number,
-        function_signature,
-        read_output,
-        utils.udf_hex_to_string(SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_symbol
-    FROM
-        base_metadata
-    WHERE
-        function_signature = '0x95d89b41'
-        AND token_symbol IS NOT NULL
-),
-token_decimals AS (
-    SELECT
-        contract_address,
-        CASE 
-            WHEN LENGTH(read_output :: STRING) <= 4300 AND read_output IS NOT NULL
-            THEN utils.udf_hex_to_int(LEFT(read_output :: STRING, 66))
-            ELSE NULL
-        END AS token_decimals,
-        LENGTH(token_decimals) AS dec_length
-    FROM
-        base_metadata
-    WHERE
-        function_signature = '0x313ce567'
-        AND read_output IS NOT NULL
-        AND read_output <> '0x'
-        AND dec_length < 3
-),
-contracts AS (
-    SELECT
-        contract_address,
-        MAX(_inserted_timestamp) AS _inserted_timestamp
-    FROM
-        base_metadata
-    GROUP BY
-        1
-)
-SELECT
-    c1.contract_address :: STRING AS contract_address,
-    token_name,
-    TRY_TO_NUMBER(token_decimals) AS token_decimals,
-    token_symbol,
-    _inserted_timestamp
-FROM
-    contracts c1
-    LEFT JOIN token_names
-    ON c1.contract_address = token_names.contract_address
-    LEFT JOIN token_symbols
-    ON c1.contract_address = token_symbols.contract_address
-    LEFT JOIN token_decimals
-    ON c1.contract_address = token_decimals.contract_address
-    AND dec_length < 3 qualify(ROW_NUMBER() over(PARTITION BY c1.contract_address
-ORDER BY
-    _inserted_timestamp DESC)) = 1
+        AND token_name IS NOT NULL),
+        token_symbols AS (
+            SELECT
+                contract_address,
+                block_number,
+                function_signature,
+                read_output,
+                utils.udf_hex_to_string(SUBSTR(read_output,(64 * 2 + 3), len(read_output))) AS token_symbol
+            FROM
+                base_metadata
+            WHERE
+                function_signature = '0x95d89b41'
+                AND token_symbol IS NOT NULL),
+                token_decimals AS (
+                    SELECT
+                        contract_address,
+                        CASE
+                            WHEN LENGTH(
+                                read_output :: STRING
+                            ) <= 4300
+                            AND read_output IS NOT NULL THEN utils.udf_hex_to_int(LEFT(read_output :: STRING, 66))
+                            ELSE NULL
+                        END AS token_decimals,
+                        LENGTH(token_decimals) AS dec_length
+                    FROM
+                        base_metadata
+                    WHERE
+                        function_signature = '0x313ce567'
+                        AND read_output IS NOT NULL
+                        AND read_output <> '0x'
+                        AND dec_length < 3
+                ),
+                contracts AS (
+                    SELECT
+                        contract_address,
+                        MAX(_inserted_timestamp) AS _inserted_timestamp
+                    FROM
+                        base_metadata
+                    GROUP BY
+                        1
+                )
+            SELECT
+                c1.contract_address :: STRING AS contract_address,
+                token_name,
+                TRY_TO_NUMBER(token_decimals) AS token_decimals,
+                token_symbol,
+                _inserted_timestamp,
+                {{ dbt_utils.generate_surrogate_key(
+                    ['c1.contract_address']
+                ) }} AS contracts_id,
+                SYSDATE() AS inserted_timestamp,
+                SYSDATE() AS modified_timestamp,
+                '{{ invocation_id }}' AS _invocation_id
+            FROM
+                contracts c1
+                LEFT JOIN token_names
+                ON c1.contract_address = token_names.contract_address
+                LEFT JOIN token_symbols
+                ON c1.contract_address = token_symbols.contract_address
+                LEFT JOIN token_decimals
+                ON c1.contract_address = token_decimals.contract_address
+                AND dec_length < 3 qualify(ROW_NUMBER() over(PARTITION BY c1.contract_address
+            ORDER BY
+                _inserted_timestamp DESC)) = 1

--- a/models/silver/core/silver__created_contracts.sql
+++ b/models/silver/core/silver__created_contracts.sql
@@ -1,6 +1,7 @@
 {{ config (
     materialized = "incremental",
     unique_key = "created_contract_address",
+    merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = "block_timestamp::DATE",
     tags = ['non_realtime']
 ) }}
@@ -12,7 +13,13 @@ SELECT
     to_address AS created_contract_address,
     from_address AS creator_address,
     input AS created_contract_input,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['to_address']
+    ) }} AS created_contracts_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('silver__traces') }}
 WHERE

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -5,6 +5,7 @@
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
     full_refresh = false,
+    merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     tags = ['decoded_logs','reorg']
 ) }}
@@ -189,7 +190,13 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    is_pending
+    is_pending,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS decoded_logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     new_records
 
@@ -214,7 +221,13 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    is_pending
+    is_pending,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS decoded_logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     missing_data
 {% endif %}

--- a/models/silver/core/silver__logs.sql
+++ b/models/silver/core/silver__logs.sql
@@ -176,7 +176,13 @@ FROM
 {% endif %}
 )
 SELECT
-    *
+    *,,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL qualify(ROW_NUMBER() over (PARTITION BY block_number, event_index
 ORDER BY

--- a/models/silver/core/silver__logs.sql
+++ b/models/silver/core/silver__logs.sql
@@ -176,7 +176,7 @@ FROM
 {% endif %}
 )
 SELECT
-    *,,
+    *,
     {{ dbt_utils.generate_surrogate_key(
         ['tx_hash', 'event_index']
     ) }} AS logs_id,

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -97,7 +97,8 @@ SELECT
     SYSDATE() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
 FROM
-    LEFT JOIN {{ ref('silver__hourly_prices_all_providers') }} A
+    bnb_base A
+    LEFT JOIN {{ ref('silver__hourly_prices_all_providers') }}
     ON DATE_TRUNC(
         'hour',
         A.block_timestamp

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -1,0 +1,109 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    cluster_by = ['block_timestamp::DATE'],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    tags = ['core','non_realtime','reorg']
+) }}
+
+WITH bnb_base AS (
+
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        identifier,
+        from_address,
+        to_address,
+        bnb_value,
+        _call_id,
+        _inserted_timestamp,
+        bnb_value_precise_raw,
+        bnb_value_precise,
+        tx_position,
+        trace_index
+    FROM
+        {{ ref('silver__traces') }}
+    WHERE
+        bnb_value > 0
+        AND tx_status = 'SUCCESS'
+        AND trace_status = 'SUCCESS'
+        AND TYPE NOT IN (
+            'DELEGATECALL',
+            'STATICCALL'
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+tx_table AS (
+    SELECT
+        block_number,
+        tx_hash,
+        from_address AS origin_from_address,
+        to_address AS origin_to_address,
+        origin_function_signature
+    FROM
+        {{ ref('silver__transactions') }}
+    WHERE
+        tx_hash IN (
+            SELECT
+                DISTINCT tx_hash
+            FROM
+                bnb_base
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    tx_hash AS tx_hash,
+    block_number AS block_number,
+    block_timestamp AS block_timestamp,
+    identifier AS identifier,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    from_address,
+    to_address,
+    bnb_value AS amount,
+    bnb_value_precise_raw AS amount_precise_raw,
+    bnb_value_precise AS amount_precise,
+    ROUND(
+        bnb_value * price,
+        2
+    ) AS amount_usd,
+    _call_id,
+    _inserted_timestamp,
+    tx_position,
+    trace_index,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'trace_index']
+    ) }} AS native_transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    LEFT JOIN {{ ref('silver__hourly_prices_all_providers') }} A
+    ON DATE_TRUNC(
+        'hour',
+        A.block_timestamp
+    ) = HOUR
+    AND token_address = LOWER('0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c')
+    JOIN tx_table USING (
+        tx_hash,
+        block_number
+    )

--- a/models/silver/core/silver__traces.sql
+++ b/models/silver/core/silver__traces.sql
@@ -403,7 +403,13 @@ SELECT
     is_pending,
     _call_id,
     _inserted_timestamp,
-    bnb_value_precise_raw
+    bnb_value_precise_raw,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'trace_index']
+    ) }} AS traces_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL qualify(ROW_NUMBER() over(PARTITION BY block_number, tx_position, trace_index
 ORDER BY

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -239,7 +239,13 @@ heal_model AS (
         has_decimal,
         has_price,
         _log_id,
-        _inserted_timestamp
+        _inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }} AS transfers_id,
+        SYSDATE() AS inserted_timestamp,
+        SYSDATE() AS modified_timestamp,
+        '{{ invocation_id }}' AS _invocation_id
     FROM
         token_transfers
 
@@ -269,7 +275,13 @@ SELECT
     has_decimal,
     has_price,
     _log_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     heal_model
 {% endif %}

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -16,10 +16,8 @@ WITH contracts AS (
   FROM
     {{ ref('silver__contracts') }}
 ),
-
 biswap AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -32,8 +30,9 @@ SELECT
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__biswap_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -44,10 +43,8 @@ WHERE
   )
 {% endif %}
 ),
-
 dodo_v1 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -60,8 +57,9 @@ SELECT
     'v1' AS version,
     _id,
     _inserted_timestamp
-FROM 
+  FROM
     {{ ref('silver_dex__dodo_v1_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -72,10 +70,8 @@ WHERE
   )
 {% endif %}
 ),
-
 dodo_v2 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -88,23 +84,22 @@ SELECT
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM 
+  FROM
     {{ ref('silver_dex__dodo_v2_pools') }}
-WHERE token0 IS NOT NULL
+  WHERE
+    token0 IS NOT NULL
+
 {% if is_incremental() %}
-AND
-  _inserted_timestamp >= (
-    SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
-    FROM
-      {{ this }}
-  )
+AND _inserted_timestamp >= (
+  SELECT
+    MAX(_inserted_timestamp) - INTERVAL '12 hours'
+  FROM
+    {{ this }}
+)
 {% endif %}
 ),
-
 frax AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -117,8 +112,9 @@ SELECT
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__fraxswap_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -129,10 +125,8 @@ WHERE
   )
 {% endif %}
 ),
-
 kyberswap_v1_dynamic AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -145,8 +139,9 @@ SELECT
     'v1-dynamic' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__kyberswap_v1_dynamic_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -157,10 +152,8 @@ WHERE
   )
 {% endif %}
 ),
-
 kyberswap_v1_static AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -173,8 +166,9 @@ SELECT
     'v1-static' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__kyberswap_v1_static_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -185,10 +179,8 @@ WHERE
   )
 {% endif %}
 ),
-
 kyberswap_v2_elastic AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -202,8 +194,9 @@ SELECT
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__kyberswap_v2_elastic_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -214,10 +207,8 @@ WHERE
   )
 {% endif %}
 ),
-
 pancakeswap_v1 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -230,8 +221,9 @@ SELECT
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__pancakeswap_v1_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -242,10 +234,8 @@ WHERE
   )
 {% endif %}
 ),
-
 pancakeswap_v2_amm AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -258,8 +248,9 @@ SELECT
     'v2-amm' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__pancakeswap_v2_amm_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -270,10 +261,8 @@ WHERE
   )
 {% endif %}
 ),
-
 pancakeswap_v2_ss AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -287,8 +276,9 @@ SELECT
     tokenA AS token0,
     tokenB AS token1,
     tokenC AS token2
-FROM
+  FROM
     {{ ref('silver_dex__pancakeswap_v2_ss_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -299,10 +289,8 @@ WHERE
   )
 {% endif %}
 ),
-
 pancakeswap_v3 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -316,8 +304,9 @@ SELECT
     'v3' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
-    {{ ref('silver_dex__pancakeswap_v3_pools') }} 
+  FROM
+    {{ ref('silver_dex__pancakeswap_v3_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -328,10 +317,8 @@ WHERE
   )
 {% endif %}
 ),
-
 sushi AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -344,8 +331,9 @@ SELECT
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__sushi_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -356,10 +344,8 @@ WHERE
   )
 {% endif %}
 ),
-
 trader_joe_v1 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -372,8 +358,9 @@ SELECT
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__trader_joe_v1_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -384,10 +371,8 @@ WHERE
   )
 {% endif %}
 ),
-
 trader_joe_v2 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -400,8 +385,9 @@ SELECT
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__trader_joe_v2_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -412,10 +398,8 @@ WHERE
   )
 {% endif %}
 ),
-
 uni_v3 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
@@ -429,8 +413,9 @@ SELECT
     'v3' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__univ3_pools') }}
+
 {% if is_incremental() %}
 WHERE
   _inserted_timestamp >= (
@@ -441,157 +426,312 @@ WHERE
   )
 {% endif %}
 ),
-
 all_pools_standard AS (
-    SELECT *
-    FROM biswap
-    UNION ALL
-    SELECT *
-    FROM dodo_v1
-    UNION ALL
-    SELECT *
-    FROM dodo_v2
-    UNION ALL
-    SELECT *
-    FROM frax
-    UNION ALL
-    SELECT *
-    FROM kyberswap_v1_dynamic
-    UNION ALL
-    SELECT *
-    FROM kyberswap_v1_static
-    UNION ALL
-    SELECT *
-    FROM pancakeswap_v1
-    UNION ALL
-    SELECT *
-    FROM pancakeswap_v2_amm
-    UNION ALL
-    SELECT *
-    FROM sushi
-    UNION ALL
-    SELECT *
-    FROM trader_joe_v1
-    UNION ALL
-    SELECT *
-    FROM trader_joe_v2
+  SELECT
+    *
+  FROM
+    biswap
+  UNION ALL
+  SELECT
+    *
+  FROM
+    dodo_v1
+  UNION ALL
+  SELECT
+    *
+  FROM
+    dodo_v2
+  UNION ALL
+  SELECT
+    *
+  FROM
+    frax
+  UNION ALL
+  SELECT
+    *
+  FROM
+    kyberswap_v1_dynamic
+  UNION ALL
+  SELECT
+    *
+  FROM
+    kyberswap_v1_static
+  UNION ALL
+  SELECT
+    *
+  FROM
+    pancakeswap_v1
+  UNION ALL
+  SELECT
+    *
+  FROM
+    pancakeswap_v2_amm
+  UNION ALL
+  SELECT
+    *
+  FROM
+    sushi
+  UNION ALL
+  SELECT
+    *
+  FROM
+    trader_joe_v1
+  UNION ALL
+  SELECT
+    *
+  FROM
+    trader_joe_v2
 ),
-
 all_pools_v3 AS (
-    SELECT *
-    FROM uni_v3
-    UNION ALL
-    SELECT *
-    FROM pancakeswap_v3
-    UNION ALL
-    SELECT *
-    FROM kyberswap_v2_elastic
+  SELECT
+    *
+  FROM
+    uni_v3
+  UNION ALL
+  SELECT
+    *
+  FROM
+    pancakeswap_v3
+  UNION ALL
+  SELECT
+    *
+  FROM
+    kyberswap_v2_elastic
 ),
-
 all_pools_other AS (
-    SELECT *
-    FROM pancakeswap_v2_ss
+  SELECT
+    *
+  FROM
+    pancakeswap_v2_ss
 ),
-
 FINAL AS (
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        contract_address,
-        pool_address,
-        CASE
-          WHEN pool_name IS NULL 
-            THEN CONCAT(  
-                    COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),
-                    '-',
-                    COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42)))
-                  ) 
-          ELSE pool_name
-        END AS pool_name,
-        OBJECT_CONSTRUCT('token0',token0,'token1',token1) AS tokens,
-        OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
-        OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
-        platform,
-        version,
-        _id,
-        p._inserted_timestamp
-    FROM all_pools_standard p 
-    LEFT JOIN contracts c0
-        ON c0.address = p.token0
-    LEFT JOIN contracts c1
-        ON c1.address = p.token1
-    UNION ALL
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        contract_address,
-        pool_address,
-        CASE
-            WHEN platform = 'kyberswap-v2' 
-                THEN CONCAT(COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),'-',COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42))),' ',COALESCE(fee,0),' ',COALESCE(tick_spacing,0))
-            WHEN platform = 'uniswap-v3' 
-                THEN CONCAT(COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),'-',COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42))),' ',COALESCE(fee,0),' ',COALESCE(tick_spacing,0),' UNI-V3 LP')
-            WHEN platform = 'pancakeswap-v3'
-                THEN CONCAT(COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),'-',COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42))),' ',COALESCE(fee,0),' ',COALESCE(tick_spacing,0),' PCS-V3 LP')
-        END AS pool_name,
-        OBJECT_CONSTRUCT('token0',token0,'token1',token1) AS tokens,
-        OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
-        OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
-        platform,
-        version,
-        _id,
-        p._inserted_timestamp
-    FROM all_pools_v3 p 
-    LEFT JOIN contracts c0
-        ON c0.address = p.token0
-    LEFT JOIN contracts c1
-        ON c1.address = p.token1
-    UNION ALL
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        contract_address,
-        pool_address,
-        CASE 
-          WHEN pool_name IS NULL 
-            THEN CONCAT(
-                  COALESCE(c0.symbol, SUBSTRING(token0, 1, 5) || '...' || SUBSTRING(token0, 39, 42)),
-                  CASE WHEN token1 IS NOT NULL THEN '-' || COALESCE(c1.symbol, SUBSTRING(token1, 1, 5) || '...' || SUBSTRING(token1, 39, 42)) ELSE '' END,
-                  CASE WHEN token2 IS NOT NULL THEN '-' || COALESCE(c2.symbol, SUBSTRING(token2, 1, 5) || '...' || SUBSTRING(token2, 39, 42)) ELSE '' END
-              ) 
-            ELSE pool_name
-        END AS pool_name,
-        OBJECT_CONSTRUCT('token0', token0, 'token1', token1, 'token2', token2) AS tokens,
-        OBJECT_CONSTRUCT('token0', c0.symbol, 'token1', c1.symbol, 'token2', c2.symbol) AS symbols,
-        OBJECT_CONSTRUCT('token0', c0.decimals, 'token1', c1.decimals, 'token2', c2.decimals) AS decimals,
-        platform,
-        version,
-        _id,
-        p._inserted_timestamp
-    FROM all_pools_other p
-    LEFT JOIN contracts c0
-        ON c0.address = p.token0
-    LEFT JOIN contracts c1
-        ON c1.address = p.token1
-    LEFT JOIN contracts c2
-        ON c2.address = p.token2
-)
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
-    platform,
-    version,
     contract_address,
     pool_address,
-    pool_name,
-    tokens,
-    symbols,
-    decimals,
+    CASE
+      WHEN pool_name IS NULL THEN CONCAT(
+        COALESCE(
+          c0.symbol,
+          CONCAT(SUBSTRING(token0, 1, 5), '...', SUBSTRING(token0, 39, 42))
+        ),
+        '-',
+        COALESCE(
+          c1.symbol,
+          CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
+        )
+      )
+      ELSE pool_name
+    END AS pool_name,
+    OBJECT_CONSTRUCT(
+      'token0',
+      token0,
+      'token1',
+      token1
+    ) AS tokens,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.symbol,
+      'token1',
+      c1.symbol
+    ) AS symbols,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.decimals,
+      'token1',
+      c1.decimals
+    ) AS decimals,
+    platform,
+    version,
     _id,
-    _inserted_timestamp
-FROM FINAL 
+    p._inserted_timestamp
+  FROM
+    all_pools_standard p
+    LEFT JOIN contracts c0
+    ON c0.address = p.token0
+    LEFT JOIN contracts c1
+    ON c1.address = p.token1
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    pool_address,
+    CASE
+      WHEN platform = 'kyberswap-v2' THEN CONCAT(
+        COALESCE(
+          c0.symbol,
+          CONCAT(SUBSTRING(token0, 1, 5), '...', SUBSTRING(token0, 39, 42))
+        ),
+        '-',
+        COALESCE(
+          c1.symbol,
+          CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
+        ),
+        ' ',
+        COALESCE(
+          fee,
+          0
+        ),
+        ' ',
+        COALESCE(
+          tick_spacing,
+          0
+        )
+      )
+      WHEN platform = 'uniswap-v3' THEN CONCAT(
+        COALESCE(
+          c0.symbol,
+          CONCAT(SUBSTRING(token0, 1, 5), '...', SUBSTRING(token0, 39, 42))
+        ),
+        '-',
+        COALESCE(
+          c1.symbol,
+          CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
+        ),
+        ' ',
+        COALESCE(
+          fee,
+          0
+        ),
+        ' ',
+        COALESCE(
+          tick_spacing,
+          0
+        ),
+        ' UNI-V3 LP'
+      )
+      WHEN platform = 'pancakeswap-v3' THEN CONCAT(
+        COALESCE(
+          c0.symbol,
+          CONCAT(SUBSTRING(token0, 1, 5), '...', SUBSTRING(token0, 39, 42))
+        ),
+        '-',
+        COALESCE(
+          c1.symbol,
+          CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
+        ),
+        ' ',
+        COALESCE(
+          fee,
+          0
+        ),
+        ' ',
+        COALESCE(
+          tick_spacing,
+          0
+        ),
+        ' PCS-V3 LP'
+      )
+    END AS pool_name,
+    OBJECT_CONSTRUCT(
+      'token0',
+      token0,
+      'token1',
+      token1
+    ) AS tokens,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.symbol,
+      'token1',
+      c1.symbol
+    ) AS symbols,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.decimals,
+      'token1',
+      c1.decimals
+    ) AS decimals,
+    platform,
+    version,
+    _id,
+    p._inserted_timestamp
+  FROM
+    all_pools_v3 p
+    LEFT JOIN contracts c0
+    ON c0.address = p.token0
+    LEFT JOIN contracts c1
+    ON c1.address = p.token1
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    pool_address,
+    CASE
+      WHEN pool_name IS NULL THEN CONCAT(
+        COALESCE(c0.symbol, SUBSTRING(token0, 1, 5) || '...' || SUBSTRING(token0, 39, 42)),
+        CASE
+          WHEN token1 IS NOT NULL THEN '-' || COALESCE(c1.symbol, SUBSTRING(token1, 1, 5) || '...' || SUBSTRING(token1, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token2 IS NOT NULL THEN '-' || COALESCE(c2.symbol, SUBSTRING(token2, 1, 5) || '...' || SUBSTRING(token2, 39, 42))
+          ELSE ''
+        END
+      )
+      ELSE pool_name
+    END AS pool_name,
+    OBJECT_CONSTRUCT(
+      'token0',
+      token0,
+      'token1',
+      token1,
+      'token2',
+      token2
+    ) AS tokens,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.symbol,
+      'token1',
+      c1.symbol,
+      'token2',
+      c2.symbol
+    ) AS symbols,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.decimals,
+      'token1',
+      c1.decimals,
+      'token2',
+      c2.decimals
+    ) AS decimals,
+    platform,
+    version,
+    _id,
+    p._inserted_timestamp
+  FROM
+    all_pools_other p
+    LEFT JOIN contracts c0
+    ON c0.address = p.token0
+    LEFT JOIN contracts c1
+    ON c1.address = p.token1
+    LEFT JOIN contracts c2
+    ON c2.address = p.token2
+)
+SELECT
+  block_number,
+  block_timestamp,
+  tx_hash,
+  platform,
+  version,
+  contract_address,
+  pool_address,
+  pool_name,
+  tokens,
+  symbols,
+  decimals,
+  _id,
+  _inserted_timestamp,
+  {{ dbt_utils.generate_surrogate_key(
+    ['block_number','platform','version']
+  ) }} AS complete_dex_liquidity_pools_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
+FROM
+  FINAL

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -9,10 +9,10 @@
 WITH contracts AS (
 
   SELECT
-    contract_address as address,
-    token_symbol as symbol,
-    token_name as NAME,
-    token_decimals as decimals
+    contract_address AS address,
+    token_symbol AS symbol,
+    token_name AS NAME,
+    token_decimals AS decimals
   FROM
     {{ ref('silver__contracts') }}
 ),
@@ -166,13 +166,25 @@ woofi_swaps AS (
     token_out,
     CONCAT(
       LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       ),
       '-',
       GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       )
     ) AS pool_name,
     _log_id,
@@ -592,13 +604,25 @@ hashflow_swaps AS (
     token_out,
     CONCAT(
       LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       ),
       '-',
       GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       )
     ) AS pool_name,
     _log_id,
@@ -654,13 +678,25 @@ hashflow_v3_swaps AS (
     token_out,
     CONCAT(
       LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       ),
       '-',
       GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       )
     ) AS pool_name,
     _log_id,
@@ -924,13 +960,25 @@ levelfi_swaps AS (
     token_out,
     CONCAT(
       LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       ),
       '-',
       GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       )
     ) AS pool_name,
     _log_id,
@@ -1090,13 +1138,25 @@ pancakeswap_v2_mm_swaps AS (
     token_out,
     CONCAT(
       LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       ),
       '-',
       GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
+        COALESCE(
+          symbol_in,
+          CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+        ),
+        COALESCE(
+          symbol_out,
+          CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+        )
       )
     ) AS pool_name,
     _log_id,
@@ -2016,7 +2076,7 @@ SELECT
   amount_in_unadj,
   amount_in,
   CASE
-    WHEN amount_out_usd IS NULL 
+    WHEN amount_out_usd IS NULL
     OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_out_usd, 0)) > 0.75
     OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_in_usd, 0)) > 0.75 THEN NULL
     ELSE amount_in_usd
@@ -2039,8 +2099,15 @@ SELECT
   symbol_in,
   symbol_out,
   f._log_id,
-  f._inserted_timestamp
+  f._inserted_timestamp,
+  {{ dbt_utils.generate_surrogate_key(
+    ['f.tx_hash','f.event_index']
+  ) }} AS complete_dex_swaps_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
 FROM
   FINAL f
-LEFT JOIN {{ ref('silver_dex__complete_dex_liquidity_pools') }} p
+  LEFT JOIN {{ ref('silver_dex__complete_dex_liquidity_pools') }}
+  p
   ON f.contract_address = p.pool_address

--- a/models/silver/labels/silver__labels.sql
+++ b/models/silver/labels/silver__labels.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'address',
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -13,7 +14,13 @@ SELECT
     label_type,
     label_subtype,
     address_name,
-    project_name
+    project_name,,
+    {{ dbt_utils.generate_surrogate_key(
+        ['address']
+    ) }} AS labels_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__labels') }}
 WHERE

--- a/models/silver/labels/silver__labels.sql
+++ b/models/silver/labels/silver__labels.sql
@@ -14,7 +14,7 @@ SELECT
     label_type,
     label_subtype,
     address_name,
-    project_name,,
+    project_name,
     {{ dbt_utils.generate_surrogate_key(
         ['address']
     ) }} AS labels_id,

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -12,6 +12,7 @@ WITH nft_base_models AS (
         block_number,
         block_timestamp,
         tx_hash,
+        event_index,
         event_type,
         platform_address,
         platform_name,
@@ -51,6 +52,7 @@ SELECT
     block_number,
     block_timestamp,
     tx_hash,
+    event_index,
     event_type,
     platform_address,
     platform_name,
@@ -90,6 +92,7 @@ SELECT
     block_number,
     block_timestamp,
     tx_hash,
+    event_index,
     event_type,
     platform_address,
     platform_name,
@@ -183,6 +186,7 @@ final_base AS (
         block_number,
         block_timestamp,
         tx_hash,
+        event_index,
         event_type,
         platform_address,
         platform_name,
@@ -292,6 +296,7 @@ label_fill_sales AS (
         block_number,
         block_timestamp,
         tx_hash,
+        event_index,
         event_type,
         platform_address,
         platform_name,
@@ -337,6 +342,30 @@ label_fill_sales AS (
     WHERE
         t.project_name IS NULL
         AND C.token_name IS NOT NULL
+),
+blocks_fill AS (
+    SELECT
+        * exclude (
+            complete_nft_sales_id,
+            inserted_timestamp,
+            modified_timestamp,
+            _invocation_id
+        )
+    FROM
+        {{ this }}
+    WHERE
+        block_number IN (
+            SELECT
+                block_number
+            FROM
+                label_fill_sales
+        )
+        AND nft_log_id NOT IN (
+            SELECT
+                nft_log_id
+            FROM
+                label_fill_sales
+        )
 )
 {% endif %},
 final_joins AS (
@@ -346,17 +375,23 @@ final_joins AS (
         final_base
 
 {% if is_incremental() %}
-UNION
+UNION ALL
 SELECT
     *
 FROM
     label_fill_sales
+UNION ALL
+SELECT
+    *
+FROM
+    blocks_fill
 {% endif %}
 )
 SELECT
     block_number,
     block_timestamp,
     tx_hash,
+    event_index,
     event_type,
     platform_address,
     platform_name,
@@ -390,7 +425,13 @@ SELECT
     nft_log_id,
     input_data,
     _log_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index', 'nft_address','tokenId','platform_exchange_version']
+    ) }} AS complete_nft_sales_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     final_joins qualify(ROW_NUMBER() over(PARTITION BY nft_log_id
 ORDER BY

--- a/models/silver/nft/silver__complete_nft_sales.yml
+++ b/models/silver/nft/silver__complete_nft_sales.yml
@@ -28,6 +28,9 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
       - name: PLATFORM_ADDRESS
         tests:
           - not_null

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -43,7 +43,7 @@ AND TO_TIMESTAMP_NTZ(_inserted_timestamp) >= (
     SELECT
         MAX(
             _inserted_timestamp
-        )
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -234,6 +234,7 @@ all_transfers AS (
         erc1155_value,
         _inserted_timestamp,
         event_index,
+        1 AS intra_event_index,
         'erc721_Transfer' AS token_transfer_type,
         CONCAT(
             _log_id,
@@ -256,6 +257,7 @@ all_transfers AS (
         erc1155_value,
         _inserted_timestamp,
         event_index,
+        1 AS intra_event_index,
         'erc1155_TransferSingle' AS token_transfer_type,
         CONCAT(
             _log_id,
@@ -280,6 +282,7 @@ all_transfers AS (
         erc1155_value,
         _inserted_timestamp,
         event_index,
+        intra_event_index,
         'erc1155_TransferBatch' AS token_transfer_type,
         CONCAT(
             _log_id,
@@ -301,6 +304,7 @@ transfer_base AS (
         block_timestamp,
         tx_hash,
         event_index,
+        intra_event_index,
         contract_address,
         C.token_name AS project_name,
         from_address,
@@ -328,6 +332,7 @@ fill_transfers AS (
         t.block_timestamp,
         t.tx_hash,
         t.event_index,
+        t.intra_event_index,
         t.contract_address,
         C.token_name AS project_name,
         t.from_address,
@@ -348,6 +353,30 @@ fill_transfers AS (
     WHERE
         t.project_name IS NULL
         AND C.token_name IS NOT NULL
+),
+blocks_fill AS (
+    SELECT
+        * exclude (
+            nft_transfers_id,
+            inserted_timestamp,
+            modified_timestamp,
+            _invocation_id
+        )
+    FROM
+        {{ this }}
+    WHERE
+        block_number IN (
+            SELECT
+                block_number
+            FROM
+                fill_transfers
+        )
+        AND _log_id NOT IN (
+            SELECT
+                _log_id
+            FROM
+                fill_transfers
+        )
 )
 {% endif %},
 final_base AS (
@@ -356,6 +385,7 @@ final_base AS (
         block_timestamp,
         tx_hash,
         event_index,
+        intra_event_index,
         contract_address,
         project_name,
         from_address,
@@ -370,12 +400,13 @@ final_base AS (
         transfer_base
 
 {% if is_incremental() %}
-UNION
+UNION ALL
 SELECT
     block_number,
     block_timestamp,
     tx_hash,
     event_index,
+    intra_event_index,
     contract_address,
     project_name,
     from_address,
@@ -395,6 +426,7 @@ SELECT
     block_timestamp,
     tx_hash,
     event_index,
+    intra_event_index,
     contract_address,
     project_name,
     from_address,
@@ -404,7 +436,13 @@ SELECT
     event_type,
     token_transfer_type,
     _log_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash','event_index','intra_event_index']
+    ) }} AS nft_transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     final_base qualify ROW_NUMBER() over (
         PARTITION BY _log_id

--- a/models/silver/nft/silver__nft_transfers.yml
+++ b/models/silver/nft/silver__nft_transfers.yml
@@ -28,6 +28,12 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: INTRA_EVENT_INDEX
+        tests:
+          - not_null
       - name: CONTRACT_ADDRESS
         tests:
           - not_null

--- a/models/silver/prices/silver__asset_metadata_all_providers.sql
+++ b/models/silver/prices/silver__asset_metadata_all_providers.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    merge_exclude_columns = ["inserted_timestamp"],
     unique_key = ['token_address','symbol','id','provider'],
     tags = ['non_realtime']
 ) }}
@@ -14,7 +15,13 @@ SELECT
     token_name AS NAME,
     token_decimals AS decimals,
     provider,
-    p._inserted_timestamp
+    p._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['token_address','symbol','id','provider']
+    ) }} AS asset_metadata_all_providers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__asset_metadata_all_providers') }}
     p

--- a/models/silver/prices/silver__hourly_prices_all_providers.sql
+++ b/models/silver/prices/silver__hourly_prices_all_providers.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['token_address', 'hour', 'provider'],
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -10,7 +11,13 @@ SELECT
     provider,
     price,
     is_imputed,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['token_address', 'hour', 'provider']
+    ) }} AS hourly_prices_all_providers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__hourly_prices_all_providers') }}
 WHERE

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['token_address', 'hour'],
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -14,7 +15,13 @@ SELECT
         C.token_symbol,
         m.symbol
     ) AS symbol,
-    c.token_decimals AS decimals
+    C.token_decimals AS decimals,
+    {{ dbt_utils.generate_surrogate_key(
+        ['p.token_address', 'p.hour']
+    ) }} AS hourly_prices_priority_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__hourly_prices_priority') }}
     p
@@ -25,6 +32,7 @@ FROM
     ON p.token_address = C.contract_address
 WHERE
     1 = 1
+
 {% if is_incremental() %}
 AND p._inserted_timestamp >= (
     SELECT


### PR DESCRIPTION
- adds export columns: `<pk>`, `inserted_timestamp`, and `modified_timestamp` to gold
- adds `_invocation_id` to silver
- creates `silver__native_transfers` to replace gold table logic, also builds `core.ez_native_transfers` to replace `core.ez_eth_transfers`
- adds generic columns to `fact_traces` and `fact_transactions`, deprecation notice on impacted columns
- adds deprecation notice to any internal columns, denoted with `_`. This is mostly just removing `_log_id` and `_inserted_timestamp` from gold to be consistent
- command 1: `dbt run -m models/silver/core/silver__native_transfers.sql models/silver/nft/silver__complete_nft_sales.sql models/silver/nft/silver__nft_transfers.sql models/silver/core/silver__transactions.sql models/silver/core/tests --full-refresh && dbt run -m models/silver models/gold`