### PR TITLE
flat traces

### DIFF
--- a/models/sources.yml
+++ b/models/sources.yml
@@ -45,6 +45,7 @@ sources:
       - name: confirm_blocks
       - name: token_balances
       - name: bnb_balances
+      - name: flat_traces
   - name: bsc_silver
     database: bsc
     schema: silver

--- a/models/streamline/bronze/core/bronze__streamline_FR_flat_traces.sql
+++ b/models/streamline/bronze/core/bronze__streamline_FR_flat_traces.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = this.identifier.split("_") [-1] %}
+{{ streamline_external_table_FR_query(
+    model,
+    partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 4), '_', 1) AS INTEGER )",
+    partition_name = "_partition_by_block_id",
+    unique_key = "block_number"
+) }}

--- a/models/streamline/bronze/core/bronze__streamline_flat_traces.sql
+++ b/models/streamline/bronze/core/bronze__streamline_flat_traces.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = this.identifier.split("_") [-1] %}
+{{ streamline_external_table_query(
+    model,
+    partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 4), '_', 1) AS INTEGER )",
+    partition_name = "_partition_by_block_id",
+    unique_key = "block_number"
+) }}

--- a/models/streamline/silver/core/complete/streamline__complete_flat_traces.sql
+++ b/models/streamline/silver/core/complete/streamline__complete_flat_traces.sql
@@ -1,0 +1,31 @@
+-- depends_on: {{ ref('bronze__streamline_traces') }}
+{{ config (
+    materialized = "incremental",
+    unique_key = "id",
+    cluster_by = "ROUND(block_number, -3)",
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(id)",
+    tags = ['streamline_core_complete']
+) }}
+
+SELECT
+    id,
+    block_number,
+    _inserted_timestamp
+FROM
+
+{% if is_incremental() %}
+{{ ref('bronze__streamline_flat_traces') }}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) _inserted_timestamp
+        FROM
+            {{ this }}
+    )
+{% else %}
+    {{ ref('bronze__streamline_FR_flat_traces') }}
+{% endif %}
+
+qualify(ROW_NUMBER() over (PARTITION BY id
+ORDER BY
+    _inserted_timestamp DESC)) = 1

--- a/models/streamline/silver/core/complete/streamline__complete_flat_traces.sql
+++ b/models/streamline/silver/core/complete/streamline__complete_flat_traces.sql
@@ -1,4 +1,4 @@
--- depends_on: {{ ref('bronze__streamline_traces') }}
+-- depends_on: {{ ref('bronze__streamline_flat_traces') }}
 {{ config (
     materialized = "incremental",
     unique_key = "id",

--- a/models/streamline/silver/core/realtime/streamline__flat_traces_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__flat_traces_realtime.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_json_rpc(object_construct('batch_call','non_batch_call', 'sql_source', '{{this.identifier}}', 'external_table', 'traces', 'recursive', 'true', 'exploded_key','[\"result\", \"calls\"]', 'method', 'debug_traceBlockByNumber', 'producer_batch_size',2000, 'producer_limit_size', 2000000, 'worker_batch_size',200))",
+        func = "{{this.schema}}.udf_json_rpc(object_construct('batch_call','non_batch_call', 'sql_source', '{{this.identifier}}', 'external_table', 'flat_traces', 'recursive', 'true', 'exploded_key','[\"result\", \"calls\"]', 'method', 'debug_traceBlockByNumber', 'producer_batch_size',2000, 'producer_limit_size', 2000000, 'worker_batch_size',200))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_core_realtime']

--- a/models/streamline/silver/core/realtime/streamline__flat_traces_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__flat_traces_realtime.sql
@@ -1,0 +1,72 @@
+{{ config (
+    materialized = "view",
+    post_hook = if_data_call_function(
+        func = "{{this.schema}}.udf_json_rpc(object_construct('batch_call','non_batch_call', 'sql_source', '{{this.identifier}}', 'external_table', 'traces', 'recursive', 'full', 'exploded_key','[\"result\", \"calls\"]', 'method', 'debug_traceBlockByNumber', 'producer_batch_size',2000, 'producer_limit_size', 2000000, 'worker_batch_size',200))",
+        target = "{{this.schema}}.{{this.identifier}}"
+    ),
+    tags = ['streamline_core_realtime']
+) }}
+
+WITH last_3_days AS (
+
+    SELECT
+        block_number
+    FROM
+        {{ ref("_block_lookback") }}
+),
+tbl AS (
+    SELECT
+        block_number,
+        block_number_hex
+    FROM
+        {{ ref("streamline__blocks") }}
+    WHERE
+        block_number IS NOT NULL
+        AND (
+            block_number >= (
+                SELECT
+                    block_number
+                FROM
+                    last_3_days
+            )
+        )
+    EXCEPT
+    SELECT
+        block_number,
+        REPLACE(
+            concat_ws('', '0x', to_char(block_number, 'XXXXXXXX')),
+            ' ',
+            ''
+        ) AS block_number_hex
+    FROM
+        {{ ref("streamline__complete_flat_traces") }}
+    WHERE
+        block_number IS NOT NULL
+        AND _inserted_timestamp >= DATEADD(
+            'day',
+            -4,
+            SYSDATE()
+        )
+        AND (
+            block_number >= (
+                SELECT
+                    block_number
+                FROM
+                    last_3_days
+            )
+        )
+)
+SELECT
+    block_number,
+    'debug_traceBlockByNumber' AS method,
+    CONCAT(
+        block_number_hex,
+        '_-_',
+        '{"tracer": "callTracer"}'
+    ) AS params
+FROM
+    tbl
+ORDER BY
+    block_number ASC
+LIMIT
+    25000

--- a/models/streamline/silver/core/realtime/streamline__flat_traces_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__flat_traces_realtime.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_json_rpc(object_construct('batch_call','non_batch_call', 'sql_source', '{{this.identifier}}', 'external_table', 'traces', 'recursive', 'full', 'exploded_key','[\"result\", \"calls\"]', 'method', 'debug_traceBlockByNumber', 'producer_batch_size',2000, 'producer_limit_size', 2000000, 'worker_batch_size',200))",
+        func = "{{this.schema}}.udf_json_rpc(object_construct('batch_call','non_batch_call', 'sql_source', '{{this.identifier}}', 'external_table', 'traces', 'recursive', 'true', 'exploded_key','[\"result\", \"calls\"]', 'method', 'debug_traceBlockByNumber', 'producer_batch_size',2000, 'producer_limit_size', 2000000, 'worker_batch_size',200))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_core_realtime']


### PR DESCRIPTION
adds secondary traces pipeline that does recursive flatten in AWS, see `models/streamline/silver/core/realtime/streamline__flat_traces_realtime.sql`: `'recursive', 'full', 'exploded_key','[\"result\", \"calls\"]'`
