### PR TITLE
add/decoder-history-range7

### DIFF
--- a/.github/workflows/dbt_run_streamline_decoder_history_range_7.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history_range_7.yml
@@ -4,7 +4,7 @@ run-name: dbt_run_streamline_decoder_history_range_7
 on:
   workflow_dispatch:
   schedule:
-    # Runs "at 14:00 UTC PM" (see https://crontab.guru)
+    # Runs "at 2:00 UTC AM" (see https://crontab.guru)
     - cron: '0 2 * * *'
     
 env:

--- a/.github/workflows/dbt_run_streamline_decoder_history_range_7.yml
+++ b/.github/workflows/dbt_run_streamline_decoder_history_range_7.yml
@@ -1,0 +1,45 @@
+name: dbt_run_streamline_decoder_history_range_7
+run-name: dbt_run_streamline_decoder_history_range_7
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs "at 14:00 UTC PM" (see https://crontab.guru)
+    - cron: '0 2 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run --threads 8 --vars '{"STREAMLINE_INVOKE_STREAMS":True,"WAIT":120}' -m "bsc_models,tag:streamline_decoded_logs_complete" "bsc_models,tag:streamline_decoded_logs_history_range_7"

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032000001_032070001.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032000001_032070001.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032070002_032140002.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032070002_032140002.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032140003_032210003.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032140003_032210003.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032210004_032280004.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032210004_032280004.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032280005_032350005.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032280005_032350005.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032350006_032420006.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032350006_032420006.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032420007_032490007.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032420007_032490007.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032490008_032560008.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032490008_032560008.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032560009_032630009.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032560009_032630009.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032630010_032700010.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032630010_032700010.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032700011_032770011.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032700011_032770011.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032770012_032840012.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032770012_032840012.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032840013_032910013.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032840013_032910013.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032910014_032980014.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032910014_032980014.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032980015_033050015.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_032980015_033050015.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033050016_033120016.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033050016_033120016.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033120017_033190017.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033120017_033190017.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033190018_033260018.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033190018_033260018.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033260019_033330019.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033260019_033330019.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033330020_033400020.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033330020_033400020.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033400021_033470021.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033400021_033470021.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033470022_033540022.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033470022_033540022.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033540023_033610023.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033540023_033610023.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033610024_033680024.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033610024_033680024.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033680025_033750025.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033680025_033750025.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033750026_033820026.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033750026_033820026.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033820027_033890027.sql
+++ b/models/streamline/silver/decoder/history/range_6/streamline__decode_logs_history_033820027_033890027.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_6']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_033890028_033960028.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_033890028_033960028.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_033960029_034030029.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_033960029_034030029.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034030030_034100030.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034030030_034100030.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034100031_034170031.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034100031_034170031.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034170032_034240032.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034170032_034240032.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034240033_034310033.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034240033_034310033.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034310034_034380034.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034310034_034380034.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034380035_034450035.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034380035_034450035.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034450036_034520036.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034450036_034520036.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034520037_034590037.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034520037_034590037.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034590038_034660038.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034590038_034660038.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034660039_034730039.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034660039_034730039.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034730040_034800040.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034730040_034800040.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034800041_034870041.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034800041_034870041.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034870042_034940042.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034870042_034940042.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034940043_035010043.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_034940043_035010043.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035010044_035080044.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035010044_035080044.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035080045_035150045.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035080045_035150045.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035150046_035220046.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035150046_035220046.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035220047_035290047.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035220047_035290047.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035290048_035360048.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035290048_035360048.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035360049_035430049.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035360049_035430049.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035430050_035500050.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035430050_035500050.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035500051_035570051.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035500051_035570051.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035570052_035640052.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035570052_035640052.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035640053_035710053.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035640053_035710053.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035710054_035780054.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035710054_035780054.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035780055_035850055.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035780055_035850055.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035850056_035920056.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035850056_035920056.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035920057_035990057.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035920057_035990057.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035990058_036060058.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_035990058_036060058.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036060059_036130059.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036060059_036130059.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036130060_036200060.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036130060_036200060.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036200061_036270061.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036200061_036270061.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036270062_036340062.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036270062_036340062.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036340063_036410063.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036340063_036410063.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036410064_036480064.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036410064_036480064.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036480065_036550065.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036480065_036550065.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036550066_036620066.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036550066_036620066.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036620067_036690067.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036620067_036690067.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036690068_036760068.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036690068_036760068.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036760069_036830069.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036760069_036830069.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036830070_036900070.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036830070_036900070.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036900071_036970071.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036900071_036970071.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036970072_037040072.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_036970072_037040072.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037040073_037110073.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037040073_037110073.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037110074_037180074.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037110074_037180074.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037180075_037250075.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037180075_037250075.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037250076_037320076.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037250076_037320076.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037320077_037390077.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037320077_037390077.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037390078_037460078.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037390078_037460078.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037460079_037530079.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037460079_037530079.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037530080_037600080.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037530080_037600080.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037600081_037670081.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037600081_037670081.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037670082_037740082.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037670082_037740082.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037740083_037810083.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037740083_037810083.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037810084_037880084.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037810084_037880084.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037880085_037950085.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037880085_037950085.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037950086_038020086.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_037950086_038020086.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038020087_038090087.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038020087_038090087.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038090088_038160088.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038090088_038160088.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038160089_038230089.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038160089_038230089.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038230090_038300090.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038230090_038300090.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038300091_038370091.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038300091_038370091.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038370092_038440092.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038370092_038440092.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038440093_038510093.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038440093_038510093.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038510094_038580094.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038510094_038580094.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038580095_038650095.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038580095_038650095.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038650096_038720096.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038650096_038720096.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038720097_038790097.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038720097_038790097.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038790098_038860098.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038790098_038860098.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038860099_038930099.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038860099_038930099.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038930100_039000100.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_038930100_039000100.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039000101_039070101.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039000101_039070101.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039070102_039140102.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039070102_039140102.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039140103_039210103.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039140103_039210103.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039210104_039280104.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039210104_039280104.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039280105_039350105.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039280105_039350105.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039350106_039420106.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039350106_039420106.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039420107_039490107.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039420107_039490107.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039490108_039560108.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039490108_039560108.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039560109_039630109.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039560109_039630109.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039630110_039700110.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039630110_039700110.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039700111_039770111.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039700111_039770111.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039770112_039840112.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039770112_039840112.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039840113_039910113.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039840113_039910113.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039910114_039980114.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039910114_039980114.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039980115_040050115.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_039980115_040050115.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040050116_040120116.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040050116_040120116.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040120117_040190117.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040120117_040190117.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040190118_040260118.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040190118_040260118.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040260119_040330119.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040260119_040330119.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040330120_040400120.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040330120_040400120.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040400121_040470121.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040400121_040470121.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040470122_040540122.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040470122_040540122.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040540123_040610123.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040540123_040610123.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040610124_040680124.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040610124_040680124.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040680125_040750125.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040680125_040750125.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040750126_040820126.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040750126_040820126.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040820127_040890127.sql
+++ b/models/streamline/silver/decoder/history/range_7/streamline__decode_logs_history_040820127_040890127.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history_range_7']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}


### PR DESCRIPTION
Requires `dbt run -m models/streamline/silver/decoder/history/range_6 models/streamline/silver/decoder/history/range_7 --full-refresh` + run history jobs